### PR TITLE
Disable Snowflake on CI

### DIFF
--- a/.github/workflows/ODBCScanner.yml
+++ b/.github/workflows/ODBCScanner.yml
@@ -746,6 +746,7 @@ jobs:
 
   snowflake-linux-amd64:
     name: Snowflake Linux (amd64)
+    if: ${{ false }}
     runs-on: ubuntu-latest
     needs: duckdb-linux-amd64
     env:


### PR DESCRIPTION
This change disables Snowflake runs on CI because they require cloud credentials and cannot be run for PRs.