### PR TITLE
Do not close connections on process exit

### DIFF
--- a/resources/scripts/run_sqllogic_tests.py
+++ b/resources/scripts/run_sqllogic_tests.py
@@ -46,8 +46,12 @@ elif args.dbms is not None:
             file_paths.append(path.join(dirpath, name))
   file_paths.append(path.join(sqllogic_tests_dir, "close.test"))
   file_paths.append(path.join(sqllogic_tests_dir, "connect.test"))
+  file_paths.append(path.join(sqllogic_tests_dir, "zfailure.test"))
 else:
   print(f"Running connect/close SQLLogic tests")
+  file_paths.append(path.join(sqllogic_tests_dir, "close.test"))
+  file_paths.append(path.join(sqllogic_tests_dir, "connect.test"))
+  file_paths.append(path.join(sqllogic_tests_dir, "zfailure.test"))
 
 odbc_conn_string = os.environ.get("ODBC_CONN_STRING", "Driver={DuckDB Driver};")
 print(f"ODBC_CONN_STRING: '{odbc_conn_string}'")

--- a/src/registries.cpp
+++ b/src/registries.cpp
@@ -13,13 +13,16 @@ static std::shared_ptr<std::mutex> SharedMutex() {
 	return mutex;
 }
 
-// todo: maybe impl determenistic closing order
+// We are NOT closing the connection on process exit - some
+// ODBC drivers don't like it and can complain to stderr or crash
 static void SharedConectionsRegistryDeleter(std::set<int64_t> *reg_ptr) {
 	auto &reg = *reg_ptr;
+	/*
 	for (int64_t conn_id : reg) {
-		OdbcConnection *conn_ptr = reinterpret_cast<OdbcConnection *>(conn_id);
-		delete conn_ptr;
+	    OdbcConnection *conn_ptr = reinterpret_cast<OdbcConnection *>(conn_id);
+	    delete conn_ptr;
 	}
+	*/
 	reg.clear();
 	delete reg_ptr;
 }

--- a/test/sql/close.test
+++ b/test/sql/close.test
@@ -12,7 +12,7 @@ require odbc_scanner
 statement error
 SELECT odbc_close()
 ----
-<REGEX>:.*Binder Error: No function matches the given name and argument types 'odbc_close\(\)'.*
+Binder Error: No function matches the given name and argument types 'odbc_close()'
 
 statement error
 SELECT odbc_close(NULL)

--- a/test/sql/connect.test
+++ b/test/sql/connect.test
@@ -12,7 +12,7 @@ require odbc_scanner
 statement error
 SET VARIABLE conn = odbc_connect()
 ----
-<REGEX>:.*Binder Error: No function matches the given name and argument types 'odbc_connect\(\)'.*
+Binder Error: No function matches the given name and argument types 'odbc_connect()'
 
 statement error
 SET VARIABLE conn = odbc_connect(NULL)
@@ -22,12 +22,12 @@ Invalid Input Error: 'odbc_connect' error: specified URL argument must be not NU
 statement error
 SET VARIABLE conn = odbc_connect('fail')
 ----
-<REGEX>:.*Invalid Input Error: 'SQLDriverConnect' failed.*
+Invalid Input Error: 'SQLDriverConnect' failed
 
 statement error
 SET VARIABLE conn = odbc_connect('Driver=fail')
 ----
-<REGEX>:.*Invalid Input Error: 'SQLDriverConnect' failed.*
+Invalid Input Error: 'SQLDriverConnect' failed
 
 statement ok
 SET VARIABLE conn = odbc_connect('ODBCSCANNER_DEBUG_CONN_STRING_ENV_VAR=ODBC_CONN_STRING')

--- a/test/sql/zfailure.test
+++ b/test/sql/zfailure.test
@@ -1,0 +1,20 @@
+# name: test/sql/zfailure.test
+# description: test that invalid queries don't lead to crashes
+# group: [sql_zfailure]
+
+require odbc_scanner
+
+statement ok
+SET VARIABLE conn = odbc_connect('ODBCSCANNER_DEBUG_CONN_STRING_ENV_VAR=ODBC_CONN_STRING')
+
+statement error
+SELECT * FROM odbc_query(getvariable('conn'), 'SELECT FAILURE')
+----
+Error:
+
+statement ok
+SELECT odbc_close(getvariable('conn'))
+
+# keep connection open to check driver's process exit behaviour
+statement ok
+SET VARIABLE conn_linger = odbc_connect('ODBCSCANNER_DEBUG_CONN_STRING_ENV_VAR=ODBC_CONN_STRING')


### PR DESCRIPTION
This change disables the attempts to auto-close on process exit the connections, that were opened with `odbc_connect()` and were never closed with `odbc_close()`.

It appeared that such closure attempt make some drivers (Snowflake) to complain to stderr and some other (DB2, ClickHouse) to crash the process.

Testing: new test is added that runs the last and leaves the connection open.