### PR TITLE
Link unixODBC statically on Linux and macOS

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -19,7 +19,7 @@ jobs:
       extension_name: odbc_scanner
       duckdb_version: v1.2.0
       ci_tools_version: main
-      extra_toolchains: python3;unixodbc;
+      extra_toolchains: python3;
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;'
       opt_in_archs: 'windows_arm64;'
       build_duckdb_shell: false

--- a/.github/workflows/ODBCScanner.yml
+++ b/.github/workflows/ODBCScanner.yml
@@ -27,6 +27,9 @@ jobs:
       DUCKDB_ODBC_LIB_URL: https://github.com/duckdb/duckdb-odbc/releases/latest/download/duckdb_odbc-linux-amd64.zip
       DUCKDB_ODBC_LIB_PATH: ${{ github.workspace }}/odbc/libduckdb_odbc.so
       DUCKDB_CAPI_LIB_PATH: ${{ github.workspace }}/libduckdb/libduckdb.so
+      VCPKG_TARGET_TRIPLET: x64-linux-release
+      VCPKG_HOST_TRIPLET: x64-linux-release
+      VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -34,15 +37,24 @@ jobs:
           fetch-depth: 0
           submodules: 'true'
 
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11.1
+        with:
+          vcpkgGitCommitId: ce613c41372b23b1f51333815feb3edd87ef8a8b
+
       - name: Dependencies
         run: |
           echo "set man-db/auto-update false" | sudo debconf-communicate
           sudo dpkg-reconfigure man-db
           sudo apt-get update -y -q -o=Dpkg::Use-Pty=0
           sudo apt-get install -y -q -o=Dpkg::Use-Pty=0 \
+            autoconf \
+            automake \
+            libtool \
+            libltdl-dev \
             ninja-build \
             python3-pyodbc \
-            unixodbc-dev
+            unixodbc
 
       - name: DuckDB ODBC Lib
         run: |
@@ -87,15 +99,26 @@ jobs:
       DUCKDB_ODBC_LIB_PATH: ${{ github.workspace }}/odbc/libduckdb_odbc.dylib
       DUCKDB_CAPI_LIB_URL: https://github.com/duckdb/duckdb/releases/latest/download/libduckdb-osx-universal.zip
       DUCKDB_CAPI_LIB_PATH: ${{ github.workspace }}/libduckdb/libduckdb.dylib
+      VCPKG_TARGET_TRIPLET: arm64-osx-release
+      VCPKG_HOST_TRIPLET: arm64-osx-release
+      VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: 'true'
 
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11.1
+        with:
+          vcpkgGitCommitId: ce613c41372b23b1f51333815feb3edd87ef8a8b
+
       - name: Dependencies
         run: |
           brew install -q \
+            autoconf \
+            automake \
+            libtool \
             ninja \
             unixodbc
 
@@ -115,6 +138,7 @@ jobs:
           ./resources/scripts/write_odbcinst_ini.sh DuckDB "${DUCKDB_ODBC_LIB_PATH}"
           ./configure/venv/bin/python -m pip install pyodbc
           ./configure/venv/bin/python ./resources/scripts/pyodbc_version.py --dbms DuckDB --conn-str "${ODBC_CONN_STRING}"
+          brew uninstall unixodbc
 
       - name: DuckDB CAPI lib
         run: |
@@ -152,6 +176,11 @@ jobs:
         with:
           fetch-depth: 0
           submodules: 'true'
+
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11.1
+        with:
+          vcpkgGitCommitId: ce613c41372b23b1f51333815feb3edd87ef8a8b
 
       - name: Dependencies
         shell: bash
@@ -214,6 +243,9 @@ jobs:
       ODBC_CONN_STRING: Driver={MSSQL Driver};Server=tcp:127.0.0.1,1433;UID=sa;PWD=P@ssword2;TrustServerCertificate=yes;
       DUCKDB_CAPI_LIB_PATH: ${{ github.workspace }}/libduckdb/libduckdb.so
       MSSQL_ODBC_LIB_PATH: /opt/microsoft/msodbcsql18/lib64/libmsodbcsql-18.5.so.1.1
+      VCPKG_TARGET_TRIPLET: x64-linux-release
+      VCPKG_HOST_TRIPLET: x64-linux-release
+      VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -221,15 +253,24 @@ jobs:
           fetch-depth: 0
           submodules: 'true'
 
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11.1
+        with:
+          vcpkgGitCommitId: ce613c41372b23b1f51333815feb3edd87ef8a8b
+
       - name: Dependencies
         run: |
           echo "set man-db/auto-update false" | sudo debconf-communicate
           sudo dpkg-reconfigure man-db
           sudo apt-get update -y -q -o=Dpkg::Use-Pty=0
           sudo apt-get install -y -q -o=Dpkg::Use-Pty=0 \
+            autoconf \
+            automake \
+            libtool \
+            libltdl-dev \
             ninja-build \
             python3-pyodbc \
-            unixodbc-dev
+            unixodbc
 
       - name: MSSQL Server
         env:
@@ -289,6 +330,9 @@ jobs:
       ODBC_CONN_STRING: Driver={PostgreSQL Driver};Server=127.0.0.1;Port:1433;Username=postgres;Password=postgres;
       DUCKDB_CAPI_LIB_PATH: ${{ github.workspace }}/libduckdb/libduckdb.so
       POSTGRES_ODBC_LIB_PATH: /usr/lib/x86_64-linux-gnu/odbc/psqlodbcw.so
+      VCPKG_TARGET_TRIPLET: x64-linux-release
+      VCPKG_HOST_TRIPLET: x64-linux-release
+      VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -296,15 +340,24 @@ jobs:
           fetch-depth: 0
           submodules: 'true'
 
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11.1
+        with:
+          vcpkgGitCommitId: ce613c41372b23b1f51333815feb3edd87ef8a8b
+
       - name: Dependencies
         run: |
           echo "set man-db/auto-update false" | sudo debconf-communicate
           sudo dpkg-reconfigure man-db
           sudo apt-get update -y -q -o=Dpkg::Use-Pty=0
           sudo apt-get install -y -q -o=Dpkg::Use-Pty=0 \
+            autoconf \
+            automake \
+            libtool \
+            libltdl-dev \
             ninja-build \
             python3-pyodbc \
-            unixodbc-dev
+            unixodbc
 
       - name: PostgreSQL Server
         run: |
@@ -351,6 +404,9 @@ jobs:
       ODBC_CONN_STRING: Driver={MariaDB Driver};SERVER=127.0.0.1;PORT=3306;USER=root;PASSWORD=root;
       DUCKDB_CAPI_LIB_PATH: ${{ github.workspace }}/libduckdb/libduckdb.so
       MARIADB_ODBC_LIB_PATH: /usr/lib/x86_64-linux-gnu/odbc/libmaodbc.so
+      VCPKG_TARGET_TRIPLET: x64-linux-release
+      VCPKG_HOST_TRIPLET: x64-linux-release
+      VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -358,15 +414,24 @@ jobs:
           fetch-depth: 0
           submodules: 'true'
 
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11.1
+        with:
+          vcpkgGitCommitId: ce613c41372b23b1f51333815feb3edd87ef8a8b
+
       - name: Dependencies
         run: |
           echo "set man-db/auto-update false" | sudo debconf-communicate
           sudo dpkg-reconfigure man-db
           sudo apt-get update -y -q -o=Dpkg::Use-Pty=0
           sudo apt-get install -y -q -o=Dpkg::Use-Pty=0 \
+            autoconf \
+            automake \
+            libtool \
+            libltdl-dev \
             ninja-build \
             python3-pyodbc \
-            unixodbc-dev
+            unixodbc
 
       - name: MariaDB Server
         run: |
@@ -416,6 +481,9 @@ jobs:
       DUCKDB_CAPI_LIB_PATH: ${{ github.workspace }}/libduckdb/libduckdb.so
       MYSQL_ODBC_LIB_URL: https://github.com/staticlibs/odbclibs_tmp/releases/download/tmp1/mysql_odbc_9.4.0_ubuntu_24.04_amd64.tar.xz
       MYSQL_ODBC_LIB_PATH: ${{ github.workspace }}/mysql_odbc_9.4.0_ubuntu_24.04_amd64/lib/libmyodbc9w.so
+      VCPKG_TARGET_TRIPLET: x64-linux-release
+      VCPKG_HOST_TRIPLET: x64-linux-release
+      VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -423,15 +491,24 @@ jobs:
           fetch-depth: 0
           submodules: 'true'
 
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11.1
+        with:
+          vcpkgGitCommitId: ce613c41372b23b1f51333815feb3edd87ef8a8b
+
       - name: Dependencies
         run: |
           echo "set man-db/auto-update false" | sudo debconf-communicate
           sudo dpkg-reconfigure man-db
           sudo apt-get update -y -q -o=Dpkg::Use-Pty=0
           sudo apt-get install -y -q -o=Dpkg::Use-Pty=0 \
+            autoconf \
+            automake \
+            libtool \
+            libltdl-dev \
             ninja-build \
             python3-pyodbc \
-            unixodbc-dev
+            unixodbc
 
       - name: MySQL Server
         run: |
@@ -480,6 +557,9 @@ jobs:
       ORACLE_ODBC_LIB_URL2: https://download.oracle.com/otn_software/linux/instantclient/2326000/instantclient-odbc-linux.x64-23.26.0.0.0.zip
       ORACLE_ODBC_LIB_PATH: ${{ github.workspace }}/instantclient_23_26/libsqora.so.23.1
       LD_LIBRARY_PATH: ${{ github.workspace }}/instantclient_23_26/
+      VCPKG_TARGET_TRIPLET: x64-linux-release
+      VCPKG_HOST_TRIPLET: x64-linux-release
+      VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -487,15 +567,24 @@ jobs:
           fetch-depth: 0
           submodules: 'true'
 
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11.1
+        with:
+          vcpkgGitCommitId: ce613c41372b23b1f51333815feb3edd87ef8a8b
+
       - name: Dependencies
         run: |
           echo "set man-db/auto-update false" | sudo debconf-communicate
           sudo dpkg-reconfigure man-db
           sudo apt-get update -y -q -o=Dpkg::Use-Pty=0
           sudo apt-get install -y -q -o=Dpkg::Use-Pty=0 \
+            autoconf \
+            automake \
+            libtool \
+            libltdl-dev \
             ninja-build \
             python3-pyodbc \
-            unixodbc-dev
+            unixodbc
 
       - name: Oracle Docker 
         run: |
@@ -551,6 +640,9 @@ jobs:
       ODBC_CONN_STRING: Driver={DB2 Driver};HostName=127.0.0.1;Port=50000;Database=testdb;UID=db2inst1;PWD=testpwd;
       DB2_ODBC_LIB_URL: https://github.com/staticlibs/odbclibs_tmp/releases/download/tmp1/v12.1.2_linuxx64_odbc_cli.tar.gz
       DB2_ODBC_LIB_PATH: ${{ github.workspace }}/odbc_cli/clidriver/lib/libdb2o.so
+      VCPKG_TARGET_TRIPLET: x64-linux-release
+      VCPKG_HOST_TRIPLET: x64-linux-release
+      VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -558,15 +650,24 @@ jobs:
           fetch-depth: 0
           submodules: 'true'
 
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11.1
+        with:
+          vcpkgGitCommitId: ce613c41372b23b1f51333815feb3edd87ef8a8b
+
       - name: Dependencies
         run: |
           echo "set man-db/auto-update false" | sudo debconf-communicate
           sudo dpkg-reconfigure man-db
           sudo apt-get update -y -q -o=Dpkg::Use-Pty=0
           sudo apt-get install -y -q -o=Dpkg::Use-Pty=0 \
+            autoconf \
+            automake \
+            libtool \
+            libltdl-dev \
             ninja-build \
             python3-pyodbc \
-            unixodbc-dev
+            unixodbc
 
       - name: DB2 Docker
         run: |
@@ -620,6 +721,9 @@ jobs:
       DUCKDB_CAPI_LIB_PATH: ${{ github.workspace }}/libduckdb/libduckdb.so
       CLICKHOUSE_ODBC_LIB_URL: https://github.com/ClickHouse/clickhouse-odbc/releases/download/1.4.3.20250807/clickhouse-odbc-linux-Clang-UnixODBC-Release.zip
       CLICKHOUSE_ODBC_LIB_PATH: ${{ github.workspace }}/clickhouse-odbc-1.4.3-Linux/lib/libclickhouseodbcw.so
+      VCPKG_TARGET_TRIPLET: x64-linux-release
+      VCPKG_HOST_TRIPLET: x64-linux-release
+      VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -627,15 +731,24 @@ jobs:
           fetch-depth: 0
           submodules: 'true'
 
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11.1
+        with:
+          vcpkgGitCommitId: ce613c41372b23b1f51333815feb3edd87ef8a8b
+
       - name: Dependencies
         run: |
           echo "set man-db/auto-update false" | sudo debconf-communicate
           sudo dpkg-reconfigure man-db
           sudo apt-get update -y -q -o=Dpkg::Use-Pty=0
           sudo apt-get install -y -q -o=Dpkg::Use-Pty=0 \
+            autoconf \
+            automake \
+            libtool \
+            libltdl-dev \
             ninja-build \
             python3-pyodbc \
-            unixodbc-dev
+            unixodbc
 
       - name: ClickHouse Server
         run: |
@@ -689,6 +802,9 @@ jobs:
       SPARK_SERVER_URL: https://blobs.duckdb.org/ci/spark-3.5.3-bin-hadoop3.tgz
       SPARK_ODBC_LIB_URL: https://databricks-bi-artifacts.s3.us-east-2.amazonaws.com/simbaspark-drivers/odbc/2.9.2/SimbaSparkODBC-2.9.2.1008-Debian-64bit.zip
       SPARK_ODBC_LIB_PATH: /opt/simba/spark/lib/64/libsparkodbc_sb64.so
+      VCPKG_TARGET_TRIPLET: x64-linux-release
+      VCPKG_HOST_TRIPLET: x64-linux-release
+      VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -696,15 +812,24 @@ jobs:
           fetch-depth: 0
           submodules: 'true'
 
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11.1
+        with:
+          vcpkgGitCommitId: ce613c41372b23b1f51333815feb3edd87ef8a8b
+
       - name: Dependencies
         run: |
           echo "set man-db/auto-update false" | sudo debconf-communicate
           sudo dpkg-reconfigure man-db
           sudo apt-get update -y -q -o=Dpkg::Use-Pty=0
           sudo apt-get install -y -q -o=Dpkg::Use-Pty=0 \
+            autoconf \
+            automake \
+            libtool \
+            libltdl-dev \
             ninja-build \
             python3-pyodbc \
-            unixodbc-dev
+            unixodbc
 
       - name: Spark Thrift Server
         run: |
@@ -755,6 +880,9 @@ jobs:
       DUCKDB_CAPI_LIB_PATH: ${{ github.workspace }}/libduckdb/libduckdb.so
       SNOWFLAKE_ODBC_LIB_URL: https://sfc-repo.snowflakecomputing.com/odbc/linux/3.12.0/snowflake_linux_x8664_odbc-3.12.0.tgz
       SNOWFLAKE_ODBC_LIB_PATH: ${{ github.workspace }}/snowflake_odbc/lib/libSnowflake.so
+      VCPKG_TARGET_TRIPLET: x64-linux-release
+      VCPKG_HOST_TRIPLET: x64-linux-release
+      VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -762,15 +890,24 @@ jobs:
           fetch-depth: 0
           submodules: 'true'
 
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11.1
+        with:
+          vcpkgGitCommitId: ce613c41372b23b1f51333815feb3edd87ef8a8b
+
       - name: Dependencies
         run: |
           echo "set man-db/auto-update false" | sudo debconf-communicate
           sudo dpkg-reconfigure man-db
           sudo apt-get update -y -q -o=Dpkg::Use-Pty=0
           sudo apt-get install -y -q -o=Dpkg::Use-Pty=0 \
+            autoconf \
+            automake \
+            libtool \
+            libltdl-dev \
             ninja-build \
             python3-pyodbc \
-            unixodbc-dev
+            unixodbc
 
       - name: Snowflake ODBC Lib
         run: |
@@ -812,6 +949,9 @@ jobs:
       GIZMOSQL_SERVER_URL: https://github.com/gizmodata/gizmosql/releases/download/v1.12.5/gizmosql_cli_linux_amd64.zip
       FLIGHTSQL_ODBC_LIB_URL: https://github.com/staticlibs/odbclibs_tmp/releases/download/tmp1/arrow-flight-sql-odbc-driver-0.9.7.479-1.x86_64.rpm
       FLIGHTSQL_ODBC_LIB_PATH: ${{ github.workspace }}/opt/arrow-flight-sql-odbc-driver/lib64/libarrow-odbc.so.0.9.7.479
+      VCPKG_TARGET_TRIPLET: x64-linux-release
+      VCPKG_HOST_TRIPLET: x64-linux-release
+      VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -819,16 +959,25 @@ jobs:
           fetch-depth: 0
           submodules: 'true'
 
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11.1
+        with:
+          vcpkgGitCommitId: ce613c41372b23b1f51333815feb3edd87ef8a8b
+
       - name: Dependencies
         run: |
           echo "set man-db/auto-update false" | sudo debconf-communicate
           sudo dpkg-reconfigure man-db
           sudo apt-get update -y -q -o=Dpkg::Use-Pty=0
           sudo apt-get install -y -q -o=Dpkg::Use-Pty=0 \
+            autoconf \
+            automake \
+            libtool \
+            libltdl-dev \
             ninja-build \
             python3-pyodbc \
             rpm2cpio \
-            unixodbc-dev
+            unixodbc
 
       - name: GizmoSQL Server
         env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,12 +28,10 @@ endif()
 ###
 project(${EXTENSION_NAME} LANGUAGES C CXX)
 
-find_package(ODBC REQUIRED)
-message(STATUS "ODBC library found at: " ${ODBC_LIBRARIES})
-
-if (NOT MSVC)
-    get_filename_component(ODBC_LIB_DIR ${ODBC_LIBRARIES} DIRECTORY)
-    find_library(ODBCINST_LIB NAMES odbcinst libodbcinst REQUIRED HINTS ${ODBC_LIB_DIR})
+if (MSVC)
+    find_package(ODBC REQUIRED)
+else ()
+    find_package(unixodbc REQUIRED)
 endif ()
 
 set(CMAKE_CXX_STANDARD "11" CACHE STRING "C++ standard to enforce")
@@ -113,9 +111,15 @@ else ()
     )
 endif ()
 
-target_link_libraries(${EXTENSION_NAME} PRIVATE
-  ${ODBC_LIBRARIES}
-)
+if (MSVC)
+    target_link_libraries(${EXTENSION_NAME} PRIVATE
+        ${ODBC_LIBRARIES}
+    )
+else ()
+    target_link_libraries(${EXTENSION_NAME} PRIVATE
+        UNIX::odbc
+    )
+endif ()
 
 SET (CAPI_ERROR_MSG "C API test suite is disabled, to enable it specify DuckDB shared library in 'DUCKDB_CAPI_LIB_PATH' environment variable.")
 

--- a/README.md
+++ b/README.md
@@ -260,3 +260,12 @@ a script is run to transform the shared library into a loadable extension by app
 to the `build/debug` directory.
 
 To create optimized release binaries, simply run `make release` instead.
+
+## License
+
+The source code in this repository is published under the [MIT license](https://github.com/duckdb/odbc-scanner/blob/main/LICENSE).
+
+The resulting binaries of this extension (that are distributed on `duckdb.org`) for Linux and macOS platforms
+contain the [unixODBC](https://www.unixodbc.org/) library that is linked statically into the shared library of the extension.
+`unixODBC` source code is published under the [LGPL v2.1 license](https://opensource.org/license/lgpl-2-1).
+Thus the binary shared library `odbc_scanner.duckdb_extension` is also published under the LGPL v2.1 license.

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "dependencies": [
+    {
+      "name": "unixodbc",
+      "platform": "!windows"
+    }
+  ],
+  "vcpkg-configuration": {
+    "overlay-ports": [
+      "./vcpkg_ports"
+    ]
+  }
+}

--- a/vcpkg_ports/unixodbc/portfile.cmake
+++ b/vcpkg_ports/unixodbc/portfile.cmake
@@ -1,0 +1,68 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO lurcher/unixODBC
+    REF 9a814155d60c44632b23d7b1bb47b17206e21db0 # v2.3.14
+    SHA512 e340f5ee76f301f0d63a29cc7a5280b80b416adcd0f09c7948de4f62e8af7b2c5a1e5bd9c3f1c5342ca01ea2d9faac49906cf11a5f49d08c169d21f6d63d835a
+    HEAD_REF master
+)
+
+set(ENV{CFLAGS} "$ENV{CFLAGS} -Wno-error=implicit-function-declaration")
+
+if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_LINUX)
+    list(APPEND OPTIONS
+        --with-included-ltdl
+        --sysconfdir=/etc
+        # --libdir=/usr/lib64
+        # --prefix=/usr
+    )
+endif()
+
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTOCONFIG
+    COPY_SOURCE
+    # NO_ADDITIONAL_PATHS
+    OPTIONS ${OPTIONS}
+)
+
+vcpkg_install_make()
+
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif ()
+
+file(REMOVE_RECURSE
+     "${CURRENT_PACKAGES_DIR}/debug/include"
+     "${CURRENT_PACKAGES_DIR}/debug/share"
+     "${CURRENT_PACKAGES_DIR}/debug/etc"
+     "${CURRENT_PACKAGES_DIR}/etc"
+     "${CURRENT_PACKAGES_DIR}/share/man"
+     "${CURRENT_PACKAGES_DIR}/share/${PORT}/man1"
+     "${CURRENT_PACKAGES_DIR}/share/${PORT}/man5"
+     "${CURRENT_PACKAGES_DIR}/share/${PORT}/man7"
+)
+
+# foreach(FILE config.h unixodbc_conf.h)
+foreach(FILE unixodbc_conf.h)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/${FILE}" "#define BIN_PREFIX \"${CURRENT_INSTALLED_DIR}/tools/unixodbc/bin\"" "")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/${FILE}" "#define DEFLIB_PATH \"${CURRENT_INSTALLED_DIR}/lib\"" "")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/${FILE}" "#define EXEC_PREFIX \"${CURRENT_INSTALLED_DIR}\"" "")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/${FILE}" "#define INCLUDE_PREFIX \"${CURRENT_INSTALLED_DIR}/include\"" "")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/${FILE}" "#define LIB_PREFIX \"${CURRENT_INSTALLED_DIR}/lib\"" "")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/${FILE}" "#define PREFIX \"${CURRENT_INSTALLED_DIR}\"" "")
+
+    # set to /etc by --sysconfdir above, no need to strip it
+    # vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/${FILE}" "#define SYSTEM_FILE_PATH \"${CURRENT_INSTALLED_DIR}/etc\"" "")
+
+    # cannot be passed to unixODBC configure through vcpkg, unused by the unixODBC itself
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/${FILE}" "#define SYSTEM_LIB_PATH \"${CURRENT_INSTALLED_DIR}/lib\"" "")
+
+endforeach()
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/unixodbcConfig.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/vcpkg_ports/unixodbc/unixodbcConfig.cmake
+++ b/vcpkg_ports/unixodbc/unixodbcConfig.cmake
@@ -1,0 +1,31 @@
+function(set_library_target NAMESPACE LIB_NAME DEBUG_DIR RELEASE_DIR INCLUDE_DIR)
+    add_library(${NAMESPACE}::${LIB_NAME} STATIC IMPORTED)
+    
+    find_library (RELEASE_LIB_FILE_NAME NAMES "lib${LIB_NAME}.a" PATHS ${RELEASE_DIR} NO_DEFAULT_PATH)
+    if (RELEASE_LIB_FILE_NAME)
+        set(LIBODBC_USE_STATIC_LIB true)
+    endif()
+    find_library (RELEASE_LIB_FILE_NAME NAMES ${LIB_NAME} PATHS ${RELEASE_DIR} NO_DEFAULT_PATH)
+    find_library (DEBUG_LIB_FILE_NAME NAMES "lib${LIB_NAME}.a" PATHS ${DEBUG_DIR} NO_DEFAULT_PATH)
+    if (DEBUG_LIB_FILE_NAME)
+        set(LIBODBC_USE_STATIC_LIB true)
+    endif()
+    find_library (DEBUG_LIB_FILE_NAME NAMES ${LIB_NAME} PATHS ${DEBUG_DIR} NO_DEFAULT_PATH)
+    set_target_properties(${NAMESPACE}::${LIB_NAME} PROPERTIES
+                          IMPORTED_CONFIGURATIONS "RELEASE;DEBUG"
+                          IMPORTED_LOCATION_RELEASE "${RELEASE_LIB_FILE_NAME}"
+                          IMPORTED_LOCATION_DEBUG "${DEBUG_LIB_FILE_NAME}"
+                          INTERFACE_INCLUDE_DIRECTORIES "${INCLUDE_DIR}"
+                          )
+    if(LIBODBC_USE_STATIC_LIB)
+        find_package(Iconv MODULE)
+        set_property(TARGET ${NAMESPACE}::${LIB_NAME} PROPERTY INTERFACE_LINK_LIBRARIES ${CMAKE_DL_LIBS} Iconv::Iconv)
+    endif()
+    set(${NAMESPACE}_${LIB_NAME}_FOUND 1)
+endfunction()
+
+get_filename_component(ROOT "${CMAKE_CURRENT_LIST_FILE}" PATH)
+get_filename_component(ROOT "${ROOT}" PATH)
+get_filename_component(ROOT "${ROOT}" PATH)
+
+set_library_target("UNIX" "odbc" "${ROOT}/debug/lib/" "${ROOT}/lib/" "${ROOT}/include/")

--- a/vcpkg_ports/unixodbc/usage
+++ b/vcpkg_ports/unixodbc/usage
@@ -1,0 +1,4 @@
+The package unixodbc is compatible with built-in CMake targets:
+
+    find_package(unixodbc REQUIRED)
+    target_link_libraries(main PRIVATE UNIX::odbc)

--- a/vcpkg_ports/unixodbc/vcpkg.json
+++ b/vcpkg_ports/unixodbc/vcpkg.json
@@ -1,0 +1,9 @@
+{
+  "name": "unixodbc",
+  "version": "2.3.11",
+  "port-version": 2,
+  "description": "unixODBC is an Open Source ODBC sub-system and an ODBC SDK for Linux, Mac OSX, and UNIX",
+  "homepage": "https://github.com/lurcher/unixODBC",
+  "license": "LGPL-2.1-only",
+  "supports": "osx | linux"
+}


### PR DESCRIPTION
This PR adds [unixODBC](https://www.unixodbc.org/) driver manager library as a statically linked dependency instead of relying on it being pre-installed in the host OS.

There are no changes for Windows where in-built system driver manager is used.

Fixes: #80