### PR TITLE
Link MSVC runtime library statically

### DIFF
--- a/.github/workflows/ODBCScanner.yml
+++ b/.github/workflows/ODBCScanner.yml
@@ -204,6 +204,13 @@ jobs:
         run: |
           make release
 
+      - name: List Symbols
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          dumpbin.exe /imports build\release\odbc_scanner.duckdb_extension
+          dumpbin.exe /exports build\release\odbc_scanner.duckdb_extension
+
       - name: C API Tests
         shell: bash
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ if (NOT MSVC)
 endif ()
 
 set(CMAKE_CXX_STANDARD "11" CACHE STRING "C++ standard to enforce")
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 if (MSVC) 
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
This PR follows up to duckdb/duckdb#19415 to use `-MT`/`MTd` flags for `odbc_scanner`.

Ref: duckdblabs/duckdb-internal#2036