### PR TITLE
Implement COPY FROM as a function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ set(EXTENSION_SOURCES
     src/functions/odbc_bind_params.cpp
     src/functions/odbc_close.cpp
     src/functions/odbc_connect.cpp
+    src/functions/odbc_copy_from.cpp
     src/functions/odbc_create_params.cpp
     src/functions/odbc_list_data_sources.cpp
     src/functions/odbc_list_drivers.cpp

--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ Optional named parameters that can change types mapping:
 
  - `decimal_columns_as_chars` (`BOOLEAN`, default: `false`): read `DECIMAL` values as `VARCHAR`s that are parsed back into `DECIMAL`s before returning them to client
  - `decimal_columns_precision_through_ard` (`BOOLEAN`, default: `false`): when reading a `DECIMAL` specify its `precision` and `scale` through "Application Row Descriptor"
+ - `decimal_columns_precision_through_ard_bind` (`BOOLEAN`, default: `false`) allow binding a `DECIMAL` column to a result buffer when its `precision` and `scale` are specified through "Application Row Descriptor"
  - `decimal_params_as_chars` (`BOOLEAN`, default: `false`): pass `DECIMAL` parameters as `VARCHAR`s
  - `reset_stmt_before_execute` (`BOOLEAN`, default: `false`): reset the prepared statement (using `SQLFreeStmt(h, SQL_CLOSE)`) before executing it
  - `time_params_as_ss_time2` (`BOOLEAN`, default: `false`): pass `TIME` parameters as SQL Server's `TIME2` values

--- a/resources/data/nl_stations_ora.sql
+++ b/resources/data/nl_stations_ora.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "nl_train_stations" (
+  "id"          NUMBER(19),
+  "code"        VARCHAR2(255),
+  "uic"         NUMBER(19),
+  "name_short"  VARCHAR2(255),
+  "name_medium" VARCHAR2(255),
+  "name_long"   VARCHAR2(255),
+  "slug"        VARCHAR2(255),
+  "country"     VARCHAR2(255),
+  "type"        VARCHAR2(255),
+  "geo_lat"     NUMBER(18,8),
+  "geo_lng"     NUMBER(18,8)  
+)

--- a/resources/data/nl_stations_short.csv
+++ b/resources/data/nl_stations_short.csv
@@ -1,0 +1,4 @@
+id,code,uic,name_short,name_medium,name_long,slug,country,type,geo_lat,geo_lng
+266,HT,8400319,Den Bosch,'s-Hertogenbosch,'s-Hertogenbosch,s-hertogenbosch,NL,knooppuntIntercitystation,51.69048,5.29362
+269,HTO,8400320,Dn Bosch O,'s-Hertogenb. O.,'s-Hertogenbosch Oost,s-hertogenbosch-oost,NL,stoptreinstation,51.700553894043,5.3183331489563
+227,HDE,8400388,'t Harde,'t Harde,'t Harde,t-harde,NL,stoptreinstation,52.4091682,5.893611

--- a/src/dbms_quirks.cpp
+++ b/src/dbms_quirks.cpp
@@ -43,7 +43,8 @@ DbmsQuirks::DbmsQuirks(OdbcConnection &conn, const std::map<std::string, ValuePt
 	} else if (conn.dbms_name == ORACLE_DBMS_NAME) {
 		this->var_len_params_long_threshold_bytes = 4000;
 		this->decimal_columns_precision_through_ard = true;
-		this->decimal_columns_bind = true;
+		this->decimal_columns_precision_through_ard_bind = true;
+		this->integral_params_as_decimals = true;
 		this->timestamp_columns_with_typename_date_as_date = true;
 
 	} else if (conn.dbms_name.rfind(DB2_DBMS_NAME_PREFIX, 0) == 0) {
@@ -70,6 +71,8 @@ DbmsQuirks::DbmsQuirks(OdbcConnection &conn, const std::map<std::string, ValuePt
 			this->timestamp_columns_as_timestamp_ns = duckdb_get_bool(val.get());
 		} else if (en.first == "decimal_columns_precision_through_ard") {
 			this->decimal_columns_precision_through_ard = duckdb_get_bool(val.get());
+		} else if (en.first == "decimal_columns_precision_through_ard_bind") {
+			this->decimal_columns_precision_through_ard_bind = duckdb_get_bool(val.get());
 		} else if (en.first == "decimal_params_as_chars") {
 			this->decimal_params_as_chars = duckdb_get_bool(val.get());
 		} else if (en.first == "reset_stmt_before_execute") {
@@ -108,6 +111,7 @@ const std::vector<std::string> DbmsQuirks::AllNames() {
 	std::vector<std::string> res;
 	res.emplace_back("decimal_columns_as_chars");
 	res.emplace_back("decimal_columns_precision_through_ard");
+	res.emplace_back("decimal_columns_precision_through_ard_bind");
 	res.emplace_back("decimal_params_as_chars");
 	res.emplace_back("reset_stmt_before_execute");
 	res.emplace_back("time_params_as_ss_time2");

--- a/src/functions/odbc_copy_from.cpp
+++ b/src/functions/odbc_copy_from.cpp
@@ -1,0 +1,438 @@
+#include "odbc_scanner.hpp"
+
+#include <cstring>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "capi_pointers.hpp"
+#include "dbms_quirks.hpp"
+#include "diagnostics.hpp"
+#include "duckdb_extension_api.hpp"
+#include "make_unique.hpp"
+#include "odbc_api.hpp"
+#include "query_context.hpp"
+#include "registries.hpp"
+#include "scanner_exception.hpp"
+#include "scanner_value.hpp"
+#include "strings.hpp"
+#include "types.hpp"
+#include "widechar.hpp"
+
+DUCKDB_EXTENSION_EXTERN
+
+static void odbc_copy_from_bind(duckdb_bind_info info) noexcept;
+static void odbc_copy_from_init(duckdb_init_info info) noexcept;
+static void odbc_copy_from_local_init(duckdb_init_info info) noexcept;
+static void odbc_copy_from_function(duckdb_function_info info, duckdb_data_chunk output) noexcept;
+
+namespace odbcscanner {
+
+namespace {
+
+enum class ExecState { UNINITIALIZED, EXECUTED, EXHAUSTED };
+
+struct BindData {
+	int64_t conn_id = 0;
+	std::string table_name;
+	std::string file_path;
+
+	BindData(int64_t conn_id_in, std::string table_name_in, std::string file_path_in)
+	    : conn_id(conn_id_in), table_name(std::move(table_name_in)), file_path(std::move(file_path_in)) {
+	}
+
+	static void Destroy(void *bdata_in) noexcept {
+		auto bdata = reinterpret_cast<BindData *>(bdata_in);
+		delete bdata;
+	}
+};
+
+struct GlobalInitData {
+	int64_t conn_id;
+	std::unique_ptr<OdbcConnection> conn_ptr;
+
+	GlobalInitData(int64_t conn_id, std::unique_ptr<OdbcConnection> conn_ptr_in)
+	    : conn_id(conn_id), conn_ptr(std::move(conn_ptr_in)) {
+		if (!conn_ptr) {
+			throw ScannerException("'odbc_copy_from' error: ODBC connection not found on global init, id: " +
+			                       std::to_string(conn_id));
+		}
+	}
+
+	~GlobalInitData() {
+		// We are not closing the connection, even in case of error,
+		// so need to return connection to registry
+		ConnectionsRegistry::Add(std::move(conn_ptr));
+	}
+
+	static void Destroy(void *gdata_in) noexcept {
+		auto gdata = reinterpret_cast<GlobalInitData *>(gdata_in);
+		delete gdata;
+	}
+};
+
+struct FileColumn {
+	std::string name;
+	duckdb_type dtype;
+
+	FileColumn();
+
+	FileColumn(std::string name_in, duckdb_type dtype_in) : name(std::move(name_in)), dtype(dtype_in) {
+	}
+};
+
+struct FileReader {
+	DatabasePtr db;
+	ConnectionPtr conn;
+	duckdb_result result;
+	ResultPtr res_ptr;
+	DataChunkPtr chunk;
+	idx_t chunk_size;
+	idx_t row_idx = 0;
+	std::vector<FileColumn> columns;
+	std::vector<duckdb_vector> vectors;
+	std::vector<uint64_t *> validities;
+
+	FileReader(DatabasePtr db_in, ConnectionPtr conn_in, duckdb_result result_in, DataChunkPtr chunk_in,
+	           std::vector<FileColumn> columns_in)
+	    : db(std::move(db_in)), conn(std::move(conn_in)), result(result_in), res_ptr(nullptr, ResultDeleter),
+	      chunk(std::move(chunk_in)), columns(std::move(columns_in)) {
+		this->res_ptr = ResultPtr(&result, ResultDeleter);
+		this->chunk_size = duckdb_data_chunk_get_size(chunk.get());
+		vectors.resize(columns.size());
+		validities.resize(columns.size());
+		for (idx_t col_idx = 0; col_idx < columns.size(); col_idx++) {
+			auto vec = duckdb_data_chunk_get_vector(chunk.get(), col_idx);
+			vectors[col_idx] = vec;
+			validities[col_idx] = duckdb_vector_get_validity(vec);
+		}
+	}
+};
+
+struct LocalInitData {
+	ExecState state = ExecState::UNINITIALIZED;
+	std::unique_ptr<FileReader> reader;
+	std::string insert_query;
+	std::unique_ptr<QueryContext> ctx;
+	std::vector<SQLSMALLINT> param_types;
+
+	LocalInitData() {
+	}
+
+	static void Destroy(void *ldata_in) noexcept {
+		auto ldata = reinterpret_cast<LocalInitData *>(ldata_in);
+		delete ldata;
+	}
+};
+
+} // namespace
+
+static void Bind(duckdb_bind_info info) {
+	auto conn_id_val = ValuePtr(duckdb_bind_get_parameter(info, 0), ValueDeleter);
+	if (duckdb_is_null_value(conn_id_val.get())) {
+		throw ScannerException("'odbc_copy_from' error: specified ODBC connection must be not NULL");
+	}
+	int64_t conn_id = duckdb_get_int64(conn_id_val.get());
+	auto conn_ptr = ConnectionsRegistry::Remove(conn_id);
+
+	if (conn_ptr.get() == nullptr) {
+		throw ScannerException("'odbc_copy_from' error: ODBC connection not found on bind, id: " +
+		                       std::to_string(conn_id));
+	}
+
+	// Return connection to registry
+	ConnectionsRegistry::Add(std::move(conn_ptr));
+
+	auto table_name_val = ValuePtr(duckdb_bind_get_parameter(info, 1), ValueDeleter);
+	if (duckdb_is_null_value(table_name_val.get())) {
+		throw ScannerException("'odbc_copy_from' error: specified table name must be not NULL");
+	}
+	auto table_name_ptr = VarcharPtr(duckdb_get_varchar(table_name_val.get()), VarcharDeleter);
+	std::string table_name(table_name_ptr.get());
+
+	auto file_path_val = ValuePtr(duckdb_bind_get_parameter(info, 2), ValueDeleter);
+	if (duckdb_is_null_value(file_path_val.get())) {
+		throw ScannerException("'odbc_copy_from' error: specified file path must be not NULL");
+	}
+	auto file_path_ptr = VarcharPtr(duckdb_get_varchar(file_path_val.get()), VarcharDeleter);
+	std::string file_path(file_path_ptr.get());
+
+	auto bdata_ptr = std::unique_ptr<BindData>(new BindData(conn_id, std::move(table_name), std::move(file_path)));
+	duckdb_bind_set_bind_data(info, bdata_ptr.release(), BindData::Destroy);
+
+	auto bool_type = LogicalTypePtr(duckdb_create_logical_type(DUCKDB_TYPE_BOOLEAN), LogicalTypeDeleter);
+	auto ubigint_type = LogicalTypePtr(duckdb_create_logical_type(DUCKDB_TYPE_UBIGINT), LogicalTypeDeleter);
+	auto double_type = LogicalTypePtr(duckdb_create_logical_type(DUCKDB_TYPE_DOUBLE), LogicalTypeDeleter);
+	auto varchar_type = LogicalTypePtr(duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR), LogicalTypeDeleter);
+
+	duckdb_bind_add_result_column(info, "completed", bool_type.get());
+	duckdb_bind_add_result_column(info, "records_inserted", ubigint_type.get());
+	duckdb_bind_add_result_column(info, "records_per_second", double_type.get());
+	duckdb_bind_add_result_column(info, "table_ddl", varchar_type.get());
+}
+
+static void GlobalInit(duckdb_init_info info) {
+	BindData &bdata = *reinterpret_cast<BindData *>(duckdb_init_get_bind_data(info));
+	// Keep the connection in global data while the function is running
+	// to not allow other threads operate on it or close it.
+	auto conn_ptr = ConnectionsRegistry::Remove(bdata.conn_id);
+	auto gdata_ptr = std::unique_ptr<GlobalInitData>(new GlobalInitData(bdata.conn_id, std::move(conn_ptr)));
+	duckdb_init_set_init_data(info, gdata_ptr.release(), GlobalInitData::Destroy);
+}
+
+static void LocalInit(duckdb_init_info info) {
+	auto ldata_ptr = std::unique_ptr<LocalInitData>(new LocalInitData());
+	duckdb_init_set_init_data(info, ldata_ptr.release(), LocalInitData::Destroy);
+}
+
+static void CheckSuccess(duckdb_state st, const std::string &msg) {
+	if (st != DuckDBSuccess) {
+		throw ScannerException("'odbc_copy_from' error: " + msg);
+	}
+}
+
+static std::unique_ptr<FileReader> OpenFile(std::string &file_path) {
+	duckdb_config config_bare = nullptr;
+	duckdb_state state_config_create = duckdb_create_config(&config_bare);
+	CheckSuccess(state_config_create, "'duckdb_create_config' failed");
+	ConfigPtr config(config_bare, ConfigDeleter);
+	duckdb_state state_config_threads = duckdb_set_config(config.get(), "threads", "1");
+	CheckSuccess(state_config_threads, "'duckdb_set_config' threads=1 failed");
+
+	duckdb_database db_bare = nullptr;
+	duckdb_state state_db = duckdb_open_ext(NULL, &db_bare, config.get(), nullptr);
+	CheckSuccess(state_db, "'duckdb_open_ext' failed");
+	DatabasePtr db(db_bare, DatabaseDeleter);
+
+	duckdb_connection conn_bare = nullptr;
+	duckdb_state state_conn = duckdb_connect(db.get(), &conn_bare);
+	CheckSuccess(state_conn, "'duckdb_connect' failed");
+	ConnectionPtr conn(conn_bare, ConnectionDeleter);
+
+	// todo: escaping, injections check, error message
+	std::string select_query = "SELECT * FROM '" + file_path + "'";
+	duckdb_result result;
+	std::memset(&result, '\0', sizeof(result));
+	duckdb_state state_select = duckdb_query(conn.get(), select_query.c_str(), &result);
+	CheckSuccess(state_select, "error reading file, path: '" + file_path + "'");
+	ResultPtr res_ptr(&result, ResultDeleter);
+
+	DataChunkPtr chunk = DataChunkPtr(duckdb_fetch_chunk(result), DataChunkDeleter);
+	CheckSuccess(chunk.get() != nullptr ? DuckDBSuccess : DuckDBError, "'duckdb_fetch_chunk' failed");
+	idx_t col_count = duckdb_data_chunk_get_column_count(chunk.get());
+
+	std::vector<FileColumn> columns;
+	columns.reserve(col_count);
+	for (idx_t col_idx = 0; col_idx < col_count; col_idx++) {
+		const char *name_ptr = duckdb_column_name(&result, col_idx);
+		CheckSuccess(name_ptr != nullptr ? DuckDBSuccess : DuckDBError,
+		             "'duckdb_column_name' failed, column index: " + std::to_string(col_idx));
+		std::string name(name_ptr);
+		duckdb_type dtype = duckdb_column_type(&result, col_idx);
+		FileColumn col(std::move(name), dtype);
+		columns.emplace_back(std::move(col));
+	}
+
+	res_ptr.release();
+	return std_make_unique<FileReader>(std::move(db), std::move(conn), result, std::move(chunk), std::move(columns));
+}
+
+static bool ReadRow(QueryContext &ctx, FileReader &reader, std::vector<ScannerValue> &row) {
+	if (reader.row_idx >= reader.chunk_size) {
+		duckdb_data_chunk chunk = duckdb_fetch_chunk(reader.result);
+		if (0 == reader.chunk_size) {
+			return false;
+		}
+		reader.chunk.reset(chunk);
+		reader.chunk_size = duckdb_data_chunk_get_size(reader.chunk.get());
+		if (0 == reader.chunk_size) {
+			return false;
+		}
+		for (idx_t col_idx = 0; col_idx < row.size(); col_idx++) {
+			auto vec = duckdb_data_chunk_get_vector(reader.chunk.get(), col_idx);
+			reader.vectors[col_idx] = vec;
+			reader.validities[col_idx] = duckdb_vector_get_validity(vec);
+		}
+		reader.row_idx = 0;
+	}
+
+	for (idx_t col_idx = 0; col_idx < row.size(); col_idx++) {
+		duckdb_vector vec = reader.vectors.at(col_idx);
+		uint64_t *validity = reader.validities.at(col_idx);
+		// todo: faster validity check
+		if (validity == nullptr || duckdb_validity_row_is_valid(validity, reader.row_idx)) {
+			FileColumn &fc = reader.columns.at(col_idx);
+			row[col_idx] = Types::ExtractNotNullParam(ctx.quirks, fc.dtype, vec, reader.row_idx, col_idx);
+		} else {
+			row[col_idx] = ScannerValue();
+		}
+	}
+	reader.row_idx++;
+
+	return true;
+}
+
+static std::string CreateInsertQuery(const std::string &table_name, const std::vector<FileColumn> &columns) {
+	std::string query = "INSERT INTO ";
+	query.append("\"");
+	query.append(table_name);
+	query.append("\"");
+	query.append("\n(");
+	for (size_t i = 0; i < columns.size(); i++) {
+		const FileColumn &col = columns.at(i);
+		query.append("\"");
+		query.append(col.name);
+		query.append("\"");
+		if (i < columns.size() - 1) {
+			query.append(",");
+		}
+		query.append("\n");
+	}
+	query.append(") VALUES (");
+	for (size_t i = 0; i < columns.size(); i++) {
+		query.append("?");
+		if (i < columns.size() - 1) {
+			query.append(",");
+		}
+	}
+	query.append(")");
+
+	return query;
+}
+
+static void CopyFrom(duckdb_function_info info, duckdb_data_chunk output) {
+	BindData &bdata = *reinterpret_cast<BindData *>(duckdb_function_get_bind_data(info));
+	GlobalInitData &gdata = *reinterpret_cast<GlobalInitData *>(duckdb_function_get_init_data(info));
+	LocalInitData &ldata = *reinterpret_cast<LocalInitData *>(duckdb_function_get_local_init_data(info));
+
+	if (ldata.state == ExecState::EXHAUSTED) {
+		duckdb_data_chunk_set_size(output, 0);
+		return;
+	}
+
+	if (ldata.state == ExecState::UNINITIALIZED) {
+		OdbcConnection &conn = *gdata.conn_ptr;
+		ldata.reader = OpenFile(bdata.file_path);
+		FileReader &reader = *ldata.reader;
+		ldata.insert_query = CreateInsertQuery(bdata.table_name, reader.columns);
+
+		HSTMT hstmt = SQL_NULL_HSTMT;
+		{
+			SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, conn.dbc, &hstmt);
+			if (!SQL_SUCCEEDED(ret)) {
+				throw ScannerException("'SQLAllocHandle' failed for STMT handle, return: " + std::to_string(ret));
+			}
+		}
+		{
+			auto wquery = WideChar::Widen(ldata.insert_query.data(), ldata.insert_query.length());
+			SQLRETURN ret = SQLPrepareW(hstmt, wquery.data(), wquery.length<SQLINTEGER>());
+			if (!SQL_SUCCEEDED(ret)) {
+				std::string diag = Diagnostics::Read(hstmt, SQL_HANDLE_STMT);
+				throw ScannerException("'SQLPrepare' failed, query: '" + ldata.insert_query +
+				                       "', return: " + std::to_string(ret) + ", diagnostics: '" + diag + "'");
+			}
+		}
+
+		DbmsQuirks quirks(conn, std::map<std::string, ValuePtr>());
+		ldata.ctx = std_make_unique<QueryContext>(ldata.insert_query, hstmt, quirks);
+		ldata.param_types = Params::CollectTypes(*ldata.ctx);
+
+		ldata.state = ExecState::EXECUTED;
+	}
+
+	QueryContext &ctx = *ldata.ctx;
+	FileReader &reader = *ldata.reader;
+
+	std::vector<ScannerValue> row;
+	row.resize(reader.columns.size());
+
+	while (ReadRow(ctx, reader, row)) {
+
+		Params::SetExpectedTypes(ctx, ldata.param_types, row);
+		Params::BindToOdbc(ctx, row);
+
+		if (ctx.quirks.reset_stmt_before_execute) {
+			SQLRETURN ret = SQLFreeStmt(ctx.hstmt, SQL_CLOSE);
+			if (!SQL_SUCCEEDED(ret)) {
+				std::string diag = Diagnostics::Read(ctx.hstmt, SQL_HANDLE_STMT);
+				throw ScannerException("'SQLFreeStmt' with SQL_CLOSE (reset_stmt_before_execute) failed, query: '" +
+				                       ctx.query + "', return: " + std::to_string(ret) + ", diagnostics: '" + diag +
+				                       "'");
+			}
+		}
+
+		{
+			SQLRETURN ret = SQLExecute(ctx.hstmt);
+			if (!SQL_SUCCEEDED(ret)) {
+				std::string diag = Diagnostics::Read(ctx.hstmt, SQL_HANDLE_STMT);
+				throw ScannerException("'SQLExecute' failed, query: '" + ctx.query +
+				                       "', return: " + std::to_string(ret) + ", diagnostics: '" + diag + "'");
+			}
+		}
+	}
+
+	duckdb_data_chunk_set_size(output, 0);
+}
+
+void OdbcCopyFromFunction::Register(duckdb_connection conn) {
+	auto fun = TableFunctionPtr(duckdb_create_table_function(), TableFunctionDeleter);
+	duckdb_table_function_set_name(fun.get(), "odbc_copy_from");
+
+	// parameters
+	auto varchar_type = LogicalTypePtr(duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR), LogicalTypeDeleter);
+	auto bigint_type = LogicalTypePtr(duckdb_create_logical_type(DUCKDB_TYPE_BIGINT), LogicalTypeDeleter);
+	auto uint_type = LogicalTypePtr(duckdb_create_logical_type(DUCKDB_TYPE_UINTEGER), LogicalTypeDeleter);
+	duckdb_table_function_add_parameter(fun.get(), bigint_type.get());  // connection handle
+	duckdb_table_function_add_parameter(fun.get(), varchar_type.get()); // destination table name
+	duckdb_table_function_add_parameter(fun.get(), varchar_type.get()); // parquet file path
+	// named args
+	duckdb_table_function_add_named_parameter(fun.get(), "batch_size", uint_type.get());
+	// duckdb_table_function_add_named_parameter(fun.get(), "column_type_mapping", map_type.get());
+
+	// callbacks
+	duckdb_table_function_set_bind(fun.get(), odbc_copy_from_bind);
+	duckdb_table_function_set_init(fun.get(), odbc_copy_from_init);
+	duckdb_table_function_set_local_init(fun.get(), odbc_copy_from_local_init);
+	duckdb_table_function_set_function(fun.get(), odbc_copy_from_function);
+
+	// register and cleanup
+	duckdb_state state = duckdb_register_table_function(conn, fun.get());
+
+	if (state != DuckDBSuccess) {
+		throw ScannerException("'odbc_copy_from' function registration failed");
+	}
+}
+
+} // namespace odbcscanner
+
+static void odbc_copy_from_bind(duckdb_bind_info info) noexcept {
+	try {
+		odbcscanner::Bind(info);
+	} catch (std::exception &e) {
+		duckdb_bind_set_error(info, e.what());
+	}
+}
+
+static void odbc_copy_from_init(duckdb_init_info info) noexcept {
+	try {
+		odbcscanner::GlobalInit(info);
+	} catch (std::exception &e) {
+		duckdb_init_set_error(info, e.what());
+	}
+}
+
+static void odbc_copy_from_local_init(duckdb_init_info info) noexcept {
+	try {
+		odbcscanner::LocalInit(info);
+	} catch (std::exception &e) {
+		duckdb_init_set_error(info, e.what());
+	}
+}
+
+static void odbc_copy_from_function(duckdb_function_info info, duckdb_data_chunk output) noexcept {
+	try {
+		odbcscanner::CopyFrom(info, output);
+	} catch (std::exception &e) {
+		duckdb_function_set_error(info, e.what());
+	}
+}

--- a/src/functions/odbc_query.cpp
+++ b/src/functions/odbc_query.cpp
@@ -401,6 +401,7 @@ void OdbcQueryFunction::Register(duckdb_connection conn) {
 	// quirks
 	duckdb_table_function_add_named_parameter(fun.get(), "decimal_columns_as_chars", bool_type.get());
 	duckdb_table_function_add_named_parameter(fun.get(), "decimal_columns_precision_through_ard", bool_type.get());
+	duckdb_table_function_add_named_parameter(fun.get(), "decimal_columns_precision_through_ard_bind", bool_type.get());
 	duckdb_table_function_add_named_parameter(fun.get(), "decimal_params_as_chars", bool_type.get());
 	duckdb_table_function_add_named_parameter(fun.get(), "reset_stmt_before_execute", bool_type.get());
 	duckdb_table_function_add_named_parameter(fun.get(), "time_params_as_ss_time2", bool_type.get());

--- a/src/include/capi_pointers.hpp
+++ b/src/include/capi_pointers.hpp
@@ -38,6 +38,24 @@ inline void VarcharDeleter(char *val) {
 	duckdb_free(val);
 }
 
+using ConfigPtr = std::unique_ptr<_duckdb_config, void (*)(duckdb_config)>;
+
+inline void ConfigDeleter(duckdb_config config) {
+	duckdb_destroy_config(&config);
+}
+
+using DatabasePtr = std::unique_ptr<_duckdb_database, void (*)(duckdb_database)>;
+
+inline void DatabaseDeleter(duckdb_database db) {
+	duckdb_close(&db);
+}
+
+using ConnectionPtr = std::unique_ptr<_duckdb_connection, void (*)(duckdb_connection)>;
+
+inline void ConnectionDeleter(duckdb_connection conn) {
+	duckdb_disconnect(&conn);
+}
+
 using ResultPtr = std::unique_ptr<duckdb_result, void (*)(duckdb_result *)>;
 
 inline void ResultDeleter(duckdb_result *res) {

--- a/src/include/dbms_quirks.hpp
+++ b/src/include/dbms_quirks.hpp
@@ -14,7 +14,7 @@ struct DbmsQuirks {
 
 	bool decimal_columns_as_chars = false;
 	bool decimal_columns_precision_through_ard = false;
-	bool decimal_columns_bind = false;
+	bool decimal_columns_precision_through_ard_bind = false;
 	bool decimal_params_as_chars = false;
 	bool reset_stmt_before_execute = false;
 	bool time_params_as_ss_time2 = false;
@@ -25,6 +25,8 @@ struct DbmsQuirks {
 	bool timestamptz_params_as_ss_timestampoffset = false;
 	bool var_len_data_single_part = false;
 	uint32_t var_len_params_long_threshold_bytes = 4000;
+
+	bool integral_params_as_decimals = false;
 
 	explicit DbmsQuirks(OdbcConnection &conn, const std::map<std::string, ValuePtr> &user_quirks);
 

--- a/src/include/odbc_scanner.hpp
+++ b/src/include/odbc_scanner.hpp
@@ -24,6 +24,10 @@ struct OdbcConnectFunction {
 	static void Register(duckdb_connection connection);
 };
 
+struct OdbcCopyFromFunction {
+	static void Register(duckdb_connection connection);
+};
+
 struct OdbcCreateParamsFunction {
 	static void Register(duckdb_connection connection);
 };

--- a/src/include/scanner_value.hpp
+++ b/src/include/scanner_value.hpp
@@ -144,6 +144,8 @@ public:
 	template <typename T>
 	T &Value();
 
+	void TransformIntegralToDecimal();
+
 private:
 	void CheckType(param_type expected);
 

--- a/src/include/types.hpp
+++ b/src/include/types.hpp
@@ -59,7 +59,7 @@ struct Types {
 
 	// Type-dispatched functions
 
-	static ScannerValue ExtractNotNullParam(DbmsQuirks &quirks, duckdb_type type_id, duckdb_vector vec,
+	static ScannerValue ExtractNotNullParam(DbmsQuirks &quirks, duckdb_type type_id, duckdb_vector vec, idx_t row_idx,
 	                                        idx_t param_idx);
 
 	static ScannerValue ExtractNotNullParam(DbmsQuirks &quirks, duckdb_value value, idx_t param_idx);
@@ -70,6 +70,8 @@ struct Types {
 
 	static void FetchAndSetResult(QueryContext &ctx, OdbcType &odbc_type, SQLSMALLINT col_idx, duckdb_vector vec,
 	                              idx_t row_idx);
+
+	static void CoalesceParameterType(QueryContext &ctx, ScannerValue &param);
 
 	static void CoalesceColumnType(QueryContext &ctx, ResultColumn &column);
 
@@ -87,7 +89,7 @@ class TypeSpecific {
 	friend struct Types;
 
 	template <typename T>
-	static ScannerValue ExtractNotNullParam(DbmsQuirks &quirks, duckdb_vector vec);
+	static ScannerValue ExtractNotNullParam(DbmsQuirks &quirks, duckdb_vector vec, idx_t row_idx);
 
 	template <typename T>
 	static ScannerValue ExtractNotNullParam(DbmsQuirks &quirks, duckdb_value value);

--- a/src/odbc_scanner.cpp
+++ b/src/odbc_scanner.cpp
@@ -17,6 +17,7 @@ static void Initialize(duckdb_connection connection, duckdb_extension_info, duck
 	OdbcCloseFunction::Register(connection);
 	OdbcCommitFunction::Register(connection);
 	OdbcConnectFunction::Register(connection);
+	OdbcCopyFromFunction::Register(connection);
 	OdbcCreateParamsFunction::Register(connection);
 	OdbcListDataSourcesFunction::Register(connection);
 	OdbcListDriversFunction::Register(connection);

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -71,7 +71,7 @@ std::vector<ScannerValue> Params::Extract(DbmsQuirks &quirks, duckdb_data_chunk 
 
 		auto child_type = LogicalTypePtr(duckdb_struct_type_child_type(struct_type.get(), i), LogicalTypeDeleter);
 		auto child_type_id = duckdb_get_type_id(child_type.get());
-		ScannerValue sp = Types::ExtractNotNullParam(quirks, child_type_id, child_vec, i);
+		ScannerValue sp = Types::ExtractNotNullParam(quirks, child_type_id, child_vec, 0, i);
 		params.emplace_back(std::move(sp));
 	}
 
@@ -142,7 +142,8 @@ void Params::SetExpectedTypes(QueryContext &ctx, const std::vector<SQLSMALLINT> 
 	}
 	for (size_t i = 0; i < actual.size(); i++) {
 		SQLSMALLINT expected_type = expected.at(i);
-		auto &param = actual.at(i);
+		ScannerValue &param = actual.at(i);
+		Types::CoalesceParameterType(ctx, param);
 		param.SetExpectedType(expected_type);
 	}
 }

--- a/src/scanner_value.cpp
+++ b/src/scanner_value.cpp
@@ -415,4 +415,58 @@ void ScannerValue::CheckType(param_type expected) {
 	}
 }
 
+void ScannerValue::TransformIntegralToDecimal() {
+	if (!(type_id == DUCKDB_TYPE_TINYINT || type_id == DUCKDB_TYPE_UTINYINT || type_id == DUCKDB_TYPE_SMALLINT ||
+	      type_id == DUCKDB_TYPE_USMALLINT || type_id == DUCKDB_TYPE_INTEGER || type_id == DUCKDB_TYPE_UINTEGER ||
+	      type_id == DUCKDB_TYPE_BIGINT || type_id == DUCKDB_TYPE_UBIGINT)) {
+		return;
+	}
+
+	duckdb_decimal dec;
+	dec.width = 0;
+	dec.scale = 0;
+	dec.value.lower = 0;
+	dec.value.upper = 0;
+
+	switch (type_id) {
+	case DUCKDB_TYPE_TINYINT:
+		dec.width = 4;
+		dec.value.lower = static_cast<uint64_t>(Value<int8_t>());
+		break;
+	case DUCKDB_TYPE_UTINYINT:
+		dec.width = 4;
+		dec.value.lower = static_cast<uint64_t>(Value<uint8_t>());
+		break;
+	case DUCKDB_TYPE_SMALLINT:
+		dec.width = 9;
+		dec.value.lower = static_cast<uint64_t>(Value<int16_t>());
+		break;
+	case DUCKDB_TYPE_USMALLINT:
+		dec.width = 9;
+		dec.value.lower = static_cast<uint64_t>(Value<uint16_t>());
+		break;
+	case DUCKDB_TYPE_INTEGER:
+		dec.width = 18;
+		dec.value.lower = static_cast<uint64_t>(Value<int32_t>());
+		break;
+	case DUCKDB_TYPE_UINTEGER:
+		dec.width = 18;
+		dec.value.lower = static_cast<uint64_t>(Value<uint32_t>());
+		break;
+	case DUCKDB_TYPE_BIGINT:
+		dec.width = 38;
+		dec.value.lower = static_cast<uint64_t>(Value<int64_t>());
+		break;
+	case DUCKDB_TYPE_UBIGINT:
+		dec.width = 38;
+		dec.value.lower = static_cast<uint64_t>(Value<uint64_t>());
+		break;
+	default:
+		throw ScannerException("Invalid integral param type: " + std::to_string(type_id));
+	}
+
+	// invoke move assignment operator
+	*this = ScannerValue(dec, false);
+}
+
 } // namespace odbcscanner

--- a/src/types/blob_type.cpp
+++ b/src/types/blob_type.cpp
@@ -16,9 +16,9 @@ namespace odbcscanner {
 static const std::string trunc_diag_code("01004");
 
 template <>
-ScannerValue TypeSpecific::ExtractNotNullParam<duckdb_blob>(DbmsQuirks &, duckdb_vector vec) {
+ScannerValue TypeSpecific::ExtractNotNullParam<duckdb_blob>(DbmsQuirks &, duckdb_vector vec, idx_t row_idx) {
 	duckdb_string_t *data = reinterpret_cast<duckdb_string_t *>(duckdb_vector_get_data(vec));
-	duckdb_string_t dstr = data[0];
+	duckdb_string_t dstr = data[row_idx];
 	const char *buf_ptr = duckdb_string_t_data(&dstr);
 	uint32_t len = duckdb_string_t_length(dstr);
 	std::vector<char> buf;

--- a/src/types/bool_type.cpp
+++ b/src/types/bool_type.cpp
@@ -11,9 +11,9 @@ DUCKDB_EXTENSION_EXTERN
 namespace odbcscanner {
 
 template <>
-ScannerValue TypeSpecific::ExtractNotNullParam<bool>(DbmsQuirks &, duckdb_vector vec) {
+ScannerValue TypeSpecific::ExtractNotNullParam<bool>(DbmsQuirks &, duckdb_vector vec, idx_t row_idx) {
 	bool *data = reinterpret_cast<bool *>(duckdb_vector_get_data(vec));
-	bool val = data[0];
+	bool val = data[row_idx];
 	return ScannerValue(val);
 }
 

--- a/src/types/float_types.cpp
+++ b/src/types/float_types.cpp
@@ -11,20 +11,20 @@ DUCKDB_EXTENSION_EXTERN
 namespace odbcscanner {
 
 template <typename FLOAT_TYPE>
-static ScannerValue ExtractNotNullParamInternal(duckdb_vector vec) {
+static ScannerValue ExtractNotNullParamInternal(duckdb_vector vec, idx_t row_idx) {
 	FLOAT_TYPE *data = reinterpret_cast<FLOAT_TYPE *>(duckdb_vector_get_data(vec));
-	FLOAT_TYPE num = data[0];
+	FLOAT_TYPE num = data[row_idx];
 	return ScannerValue(num);
 }
 
 template <>
-ScannerValue TypeSpecific::ExtractNotNullParam<float>(DbmsQuirks &, duckdb_vector vec) {
-	return ExtractNotNullParamInternal<float>(vec);
+ScannerValue TypeSpecific::ExtractNotNullParam<float>(DbmsQuirks &, duckdb_vector vec, idx_t row_idx) {
+	return ExtractNotNullParamInternal<float>(vec, row_idx);
 }
 
 template <>
-ScannerValue TypeSpecific::ExtractNotNullParam<double>(DbmsQuirks &, duckdb_vector vec) {
-	return ExtractNotNullParamInternal<double>(vec);
+ScannerValue TypeSpecific::ExtractNotNullParam<double>(DbmsQuirks &, duckdb_vector vec, idx_t row_idx) {
+	return ExtractNotNullParamInternal<double>(vec, row_idx);
 }
 
 template <>

--- a/src/types/integer_types.cpp
+++ b/src/types/integer_types.cpp
@@ -53,50 +53,50 @@ std::pair<int64_t, bool> Types::ExtractFunctionArg<int64_t>(duckdb_data_chunk ch
 }
 
 template <typename INT_TYPE>
-static ScannerValue ExtractNotNullParamInternal(duckdb_vector vec) {
+static ScannerValue ExtractNotNullParamInternal(duckdb_vector vec, idx_t row_idx) {
 	INT_TYPE *data = reinterpret_cast<INT_TYPE *>(duckdb_vector_get_data(vec));
-	INT_TYPE num = data[0];
+	INT_TYPE num = data[row_idx];
 	return ScannerValue(num);
 }
 
 template <>
-ScannerValue TypeSpecific::ExtractNotNullParam<int8_t>(DbmsQuirks &, duckdb_vector vec) {
-	return ExtractNotNullParamInternal<int8_t>(vec);
+ScannerValue TypeSpecific::ExtractNotNullParam<int8_t>(DbmsQuirks &, duckdb_vector vec, idx_t row_idx) {
+	return ExtractNotNullParamInternal<int8_t>(vec, row_idx);
 }
 
 template <>
-ScannerValue TypeSpecific::ExtractNotNullParam<uint8_t>(DbmsQuirks &, duckdb_vector vec) {
-	return ExtractNotNullParamInternal<uint8_t>(vec);
+ScannerValue TypeSpecific::ExtractNotNullParam<uint8_t>(DbmsQuirks &, duckdb_vector vec, idx_t row_idx) {
+	return ExtractNotNullParamInternal<uint8_t>(vec, row_idx);
 }
 
 template <>
-ScannerValue TypeSpecific::ExtractNotNullParam<int16_t>(DbmsQuirks &, duckdb_vector vec) {
-	return ExtractNotNullParamInternal<int16_t>(vec);
+ScannerValue TypeSpecific::ExtractNotNullParam<int16_t>(DbmsQuirks &, duckdb_vector vec, idx_t row_idx) {
+	return ExtractNotNullParamInternal<int16_t>(vec, row_idx);
 }
 
 template <>
-ScannerValue TypeSpecific::ExtractNotNullParam<uint16_t>(DbmsQuirks &, duckdb_vector vec) {
-	return ExtractNotNullParamInternal<uint16_t>(vec);
+ScannerValue TypeSpecific::ExtractNotNullParam<uint16_t>(DbmsQuirks &, duckdb_vector vec, idx_t row_idx) {
+	return ExtractNotNullParamInternal<uint16_t>(vec, row_idx);
 }
 
 template <>
-ScannerValue TypeSpecific::ExtractNotNullParam<int32_t>(DbmsQuirks &, duckdb_vector vec) {
-	return ExtractNotNullParamInternal<int32_t>(vec);
+ScannerValue TypeSpecific::ExtractNotNullParam<int32_t>(DbmsQuirks &, duckdb_vector vec, idx_t row_idx) {
+	return ExtractNotNullParamInternal<int32_t>(vec, row_idx);
 }
 
 template <>
-ScannerValue TypeSpecific::ExtractNotNullParam<uint32_t>(DbmsQuirks &, duckdb_vector vec) {
-	return ExtractNotNullParamInternal<uint32_t>(vec);
+ScannerValue TypeSpecific::ExtractNotNullParam<uint32_t>(DbmsQuirks &, duckdb_vector vec, idx_t row_idx) {
+	return ExtractNotNullParamInternal<uint32_t>(vec, row_idx);
 }
 
 template <>
-ScannerValue TypeSpecific::ExtractNotNullParam<int64_t>(DbmsQuirks &, duckdb_vector vec) {
-	return ExtractNotNullParamInternal<int64_t>(vec);
+ScannerValue TypeSpecific::ExtractNotNullParam<int64_t>(DbmsQuirks &, duckdb_vector vec, idx_t row_idx) {
+	return ExtractNotNullParamInternal<int64_t>(vec, row_idx);
 }
 
 template <>
-ScannerValue TypeSpecific::ExtractNotNullParam<uint64_t>(DbmsQuirks &, duckdb_vector vec) {
-	return ExtractNotNullParamInternal<uint64_t>(vec);
+ScannerValue TypeSpecific::ExtractNotNullParam<uint64_t>(DbmsQuirks &, duckdb_vector vec, idx_t row_idx) {
+	return ExtractNotNullParamInternal<uint64_t>(vec, row_idx);
 }
 
 template <>

--- a/src/types/temporal_types.cpp
+++ b/src/types/temporal_types.cpp
@@ -80,27 +80,30 @@ static ScannerValue CreateParamFromTimestampNs(DbmsQuirks &quirks, duckdb_timest
 }
 
 template <>
-ScannerValue TypeSpecific::ExtractNotNullParam<duckdb_date_struct>(DbmsQuirks &, duckdb_vector vec) {
+ScannerValue TypeSpecific::ExtractNotNullParam<duckdb_date_struct>(DbmsQuirks &, duckdb_vector vec, idx_t row_idx) {
 	duckdb_date *data = reinterpret_cast<duckdb_date *>(duckdb_vector_get_data(vec));
-	return CreateParamFromDate(data[0]);
+	return CreateParamFromDate(data[row_idx]);
 }
 
 template <>
-ScannerValue TypeSpecific::ExtractNotNullParam<duckdb_time_struct>(DbmsQuirks &quirks, duckdb_vector vec) {
+ScannerValue TypeSpecific::ExtractNotNullParam<duckdb_time_struct>(DbmsQuirks &quirks, duckdb_vector vec,
+                                                                   idx_t row_idx) {
 	duckdb_time *data = reinterpret_cast<duckdb_time *>(duckdb_vector_get_data(vec));
-	return CreateParamFromTime(quirks, data[0]);
+	return CreateParamFromTime(quirks, data[row_idx]);
 }
 
 template <>
-ScannerValue TypeSpecific::ExtractNotNullParam<duckdb_timestamp_struct>(DbmsQuirks &quirks, duckdb_vector vec) {
+ScannerValue TypeSpecific::ExtractNotNullParam<duckdb_timestamp_struct>(DbmsQuirks &quirks, duckdb_vector vec,
+                                                                        idx_t row_idx) {
 	duckdb_timestamp *data = reinterpret_cast<duckdb_timestamp *>(duckdb_vector_get_data(vec));
-	return CreateParamFromTimestamp(quirks, data[0]);
+	return CreateParamFromTimestamp(quirks, data[row_idx]);
 }
 
 template <>
-ScannerValue TypeSpecific::ExtractNotNullParam<TimestampNsStruct>(DbmsQuirks &quirks, duckdb_vector vec) {
+ScannerValue TypeSpecific::ExtractNotNullParam<TimestampNsStruct>(DbmsQuirks &quirks, duckdb_vector vec,
+                                                                  idx_t row_idx) {
 	duckdb_timestamp_ns *data = reinterpret_cast<duckdb_timestamp_ns *>(duckdb_vector_get_data(vec));
-	return CreateParamFromTimestampNs(quirks, data[0]);
+	return CreateParamFromTimestampNs(quirks, data[row_idx]);
 }
 
 template <>

--- a/src/types/uuid_type.cpp
+++ b/src/types/uuid_type.cpp
@@ -14,9 +14,9 @@ DUCKDB_EXTENSION_EXTERN
 namespace odbcscanner {
 
 template <>
-ScannerValue TypeSpecific::ExtractNotNullParam<ScannerUuid>(DbmsQuirks &, duckdb_vector vec) {
+ScannerValue TypeSpecific::ExtractNotNullParam<ScannerUuid>(DbmsQuirks &, duckdb_vector vec, idx_t row_idx) {
 	duckdb_uhugeint *data = reinterpret_cast<duckdb_uhugeint *>(duckdb_vector_get_data(vec));
-	duckdb_uhugeint num = data[0];
+	duckdb_uhugeint num = data[row_idx];
 	num.upper ^= (std::numeric_limits<int64_t>::min)();
 	ScannerUuid uuid(num);
 	return ScannerValue(std::move(uuid));

--- a/src/types/varchar_type.cpp
+++ b/src/types/varchar_type.cpp
@@ -48,9 +48,9 @@ std::pair<std::string, bool> Types::ExtractFunctionArg<std::string>(duckdb_data_
 }
 
 template <>
-ScannerValue TypeSpecific::ExtractNotNullParam<std::string>(DbmsQuirks &, duckdb_vector vec) {
+ScannerValue TypeSpecific::ExtractNotNullParam<std::string>(DbmsQuirks &, duckdb_vector vec, idx_t row_idx) {
 	duckdb_string_t *data = reinterpret_cast<duckdb_string_t *>(duckdb_vector_get_data(vec));
-	duckdb_string_t dstr = data[0];
+	duckdb_string_t dstr = data[row_idx];
 	const char *cstr = duckdb_string_t_data(&dstr);
 	uint32_t len = duckdb_string_t_length(dstr);
 	return ScannerValue(cstr, len);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,7 @@ endif ()
 add_executable(test_${EXTENSION_NAME}
     test_basic.cpp
     test_common.cpp
+    test_copy.cpp
     test_dates.cpp
     test_decimal.cpp
     test_list_env.cpp

--- a/test/sql/duckdb/user_quirks.test
+++ b/test/sql/duckdb/user_quirks.test
@@ -13,6 +13,7 @@ SELECT * FROM odbc_query(
   'SELECT 42',
 	decimal_columns_as_chars=TRUE,
 	decimal_columns_precision_through_ard=TRUE,
+	decimal_columns_precision_through_ard_bind=TRUE,
 	decimal_params_as_chars=TRUE,
 	reset_stmt_before_execute=TRUE,
 	time_params_as_ss_time2=TRUE,

--- a/test/sql/oracle/03_number.test
+++ b/test/sql/oracle/03_number.test
@@ -21,7 +21,7 @@ DECIMAL(4,3)
 
 query I
 SELECT column_type from (
-  DESCRIBE SELECT * FROM odbc_query(getvariable('conn'), 'SELECT CAST(''1.234'' AS NUMERIC(4,3)) FROM dual')
+  DESCRIBE SELECT * FROM odbc_query(getvariable('conn'), 'SELECT CAST(''1.234'' AS NUMBER(4,3)) FROM dual')
 )
 ----
 DECIMAL(4,3)

--- a/test/sql/snowflake/10_timestamp_ltz.test
+++ b/test/sql/snowflake/10_timestamp_ltz.test
@@ -74,7 +74,7 @@ EXECUTE p1
 # 1969-12-31 15:30:00
 
 # todo: check me
-# CI shift discrpepancy
+# CI shift discrepancy
 # statement ok
 # EXECUTE p1_bind('0001-01-01 00:00:00.000000'::TIMESTAMP)
 

--- a/test/test_common.cpp
+++ b/test/test_common.cpp
@@ -180,6 +180,12 @@ int64_t Result::Value<int64_t>(idx_t col_idx, idx_t row_idx) {
 }
 
 template <>
+double Result::Value<double>(idx_t col_idx, idx_t row_idx) {
+	double *data = NotNullData<double>(DUCKDB_TYPE_DOUBLE, chunk, cur_row_idx, col_idx, row_idx);
+	return data[row_idx];
+}
+
+template <>
 std::string Result::Value<std::string>(idx_t col_idx, idx_t row_idx) {
 	duckdb_string_t *data = NotNullData<duckdb_string_t>(DUCKDB_TYPE_VARCHAR, chunk, cur_row_idx, col_idx, row_idx);
 	duckdb_string_t dstr = data[row_idx];

--- a/test/test_copy.cpp
+++ b/test/test_copy.cpp
@@ -1,0 +1,76 @@
+#include "test_common.hpp"
+
+#include <fstream>
+#include <sstream>
+
+static const std::string group_name = "[copy]";
+
+TEST_CASE("Copy from file into Oracle", group_name) {
+	if (!DBMSConfigured("Oracle")) {
+		return;
+	}
+
+	std::ifstream fstream("resources/data/nl_stations_ora.sql", std::ios::in | std::ios::binary);
+	std::stringstream sstream;
+	sstream << fstream.rdbuf();
+	std::string ddl = sstream.str();
+
+	ScannerConn sc;
+	{
+		Result res;
+		duckdb_state st = duckdb_query(sc.conn, R"(
+  SELECT * FROM odbc_query(getvariable('conn'), 'DROP TABLE "nl_train_stations"', ignore_exec_failure=TRUE)
+  )",
+		                               res.Get());
+		REQUIRE(QuerySuccess(res.Get(), st));
+	}
+	{
+		Result res;
+		duckdb_state st = duckdb_query(sc.conn,
+		                               (R"(
+  SELECT * FROM odbc_query(getvariable('conn'), ')" +
+		                                ddl + R"(')
+  )")
+		                                   .c_str(),
+		                               res.Get());
+		REQUIRE(QuerySuccess(res.Get(), st));
+	}
+	{
+		Result res;
+		duckdb_state st = duckdb_query(sc.conn, R"(
+  SELECT * FROM odbc_copy_from(getvariable('conn'), 'nl_train_stations', 'resources/data/nl_stations_short.csv')
+  )",
+		                               res.Get());
+		REQUIRE(QuerySuccess(res.Get(), st));
+	}
+	{
+		Result res;
+		duckdb_state st = duckdb_query(sc.conn, R"(
+  SELECT * FROM odbc_query(getvariable('conn'), 'SELECT count(*) FROM "nl_train_stations"')
+  )",
+		                               res.Get());
+		REQUIRE(QuerySuccess(res.Get(), st));
+		REQUIRE(res.NextChunk());
+		REQUIRE(res.Value<double>(0, 0) == 3);
+	}
+	{
+		Result res;
+		duckdb_state st = duckdb_query(sc.conn, R"(
+  SELECT * FROM odbc_query(getvariable('conn'), 'SELECT "id", "code", "geo_lng" FROM "nl_train_stations" WHERE "id" = 227')
+  )",
+		                               res.Get());
+		REQUIRE(QuerySuccess(res.Get(), st));
+		REQUIRE(res.NextChunk());
+		REQUIRE(res.DecimalValue<int64_t>(0, 0) == 227);
+		REQUIRE(res.Value<std::string>(1, 0) == "HDE");
+		REQUIRE(res.Value<int64_t>(2, 0) == 589361100);
+	}
+	{
+		Result res;
+		duckdb_state st = duckdb_query(sc.conn, R"(
+  SELECT * FROM odbc_query(getvariable('conn'), 'DROP TABLE "nl_train_stations"')
+  )",
+		                               res.Get());
+		REQUIRE(QuerySuccess(res.Get(), st));
+	}
+}


### PR DESCRIPTION
This PR implements `odbc_copy_from` function that is intended to cover the `COPY FROM` statement functionality ([ref](https://duckdb.org/docs/stable/sql/statements/copy)) that currently cannot be implemented directly until Storage Extensions are available in DuckDB C API.

Normal `COPY FROM` is used to copy records from a file (available in local FS or over HTTP) into a `lineitem` table like this:

```sql
COPY lineitem FROM 'path/to/lineitem.parquet'
```

The same now can be done over ODBC, for example for  a `lineitem` table residing in remote DB:

```sql
SELECT * FROM odbc_copy_from(getvariable('conn'), 'lineitem', 'path/to/lineitem.parquet')
```

When `odbc_copy_from` is called, `odbc_scanner` reads the specified file by running `SELECT * FROM '<specified_file_path>'` (so all file types supported by DuckDB can be read - `.csv`, `.parquet`, `.json`) and
inserts the records from the file into the remote table using prepared statement and query parameters binding.

Current implementation is **experimental**, it is limited in functionality (cannot yet create a table on the fly, does not support batching, does not do transactions automatically) and is only tested with Oracle. `odbc_copy_from` function is going to be added to the list of documented functions (in README) when the implementation is more mature.