### PR TITLE
Rename VARINT to BIGNUM in vendored headers

### DIFF
--- a/duckdb_capi/duckdb.h
+++ b/duckdb_capi/duckdb.h
@@ -132,7 +132,7 @@ typedef enum DUCKDB_TYPE {
 	// ANY type
 	DUCKDB_TYPE_ANY = 34,
 	// duckdb_varint
-	DUCKDB_TYPE_VARINT = 35,
+	DUCKDB_TYPE_BIGNUM = 35,
 	// SQLNULL type
 	DUCKDB_TYPE_SQLNULL = 36,
 } duckdb_type;

--- a/src/types/types.cpp
+++ b/src/types/types.cpp
@@ -459,8 +459,8 @@ std::string Types::ToString(duckdb_type type_id) {
 		return "DUCKDB_TYPE_TIMESTAMP_TZ";
 	case DUCKDB_TYPE_ANY:
 		return "DUCKDB_TYPE_ANY";
-	case DUCKDB_TYPE_VARINT:
-		return "DUCKDB_TYPE_VARINT";
+	case DUCKDB_TYPE_BIGNUM:
+		return "DUCKDB_TYPE_BIGNUM";
 	case DUCKDB_TYPE_SQLNULL:
 		return "DUCKDB_TYPE_SQLNULL";
 	default:
@@ -539,8 +539,8 @@ duckdb_type Types::FromString(const std::string &type_name) {
 		return DUCKDB_TYPE_TIMESTAMP_TZ;
 	} else if (type_name == "DUCKDB_TYPE_ANY") {
 		return DUCKDB_TYPE_ANY;
-	} else if (type_name == "DUCKDB_TYPE_VARINT") {
-		return DUCKDB_TYPE_VARINT;
+	} else if (type_name == "DUCKDB_TYPE_BIGNUM") {
+		return DUCKDB_TYPE_BIGNUM;
 	} else if (type_name == "DUCKDB_TYPE_SQLNULL") {
 		return DUCKDB_TYPE_SQLNULL;
 	} else {


### PR DESCRIPTION
This PR renames `VARINT` to `BIGNUM` in `duckdb.h` that is included in the extension tree. This is necessary to be source-compatible with newer versions of headers after duckdb/duckdb#18547.

This should not break binary compatibility for v1.2.0+ versions that don't include duckdb/duckdb#18547.