### PR TITLE
Support CMake-only builds for engine CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,29 @@ option(DUCKDB_WASM_EXTENSIONS "Whether compiling for Wasm target" OFF)
 ###
 # Configuration
 ###
+
+# CMake-only build config
+if(DEFINED DUCKDB_MODULE_BASE_DIR) 
+    set(EXTENSION_NAME odbc_scanner)
+    set(${EXTENSION_NAME}_CMAKE_ONLY_BUILD TRUE)
+
+    set(TARGET_DUCKDB_VERSION_MAJOR 1)
+    set(TARGET_DUCKDB_VERSION_MINOR 2)
+    set(TARGET_DUCKDB_VERSION_PATCH 0)
+
+    find_package(Git)
+    if(Git_FOUND)
+        execute_process(
+            COMMAND ${GIT_EXECUTABLE} rev-parse --short=10 HEAD
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            OUTPUT_VARIABLE ${EXTENSION_NAME}_GIT_COMMIT_HASH
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+    else()
+        message(FATAL_ERROR "Unable to get Git version for extension: ${EXTENSION_NAME}")
+    endif()
+endif()
+# end CMake-only build config
+
 if(NOT DEFINED EXTENSION_NAME)
     message(FATAL_ERROR "DuckDB extension name is required")
 endif()
@@ -34,16 +57,16 @@ message(STATUS "ODBC library found at: " ${ODBC_LIBRARIES})
 if (NOT MSVC)
     get_filename_component(ODBC_LIB_DIR ${ODBC_LIBRARIES} DIRECTORY)
     find_library(ODBCINST_LIB NAMES odbcinst libodbcinst REQUIRED HINTS ${ODBC_LIB_DIR})
-endif ()
+endif()
 
 set(CMAKE_CXX_STANDARD "11" CACHE STRING "C++ standard to enforce")
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
-if (MSVC) 
+if(MSVC) 
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_CURRENT_BINARY_DIR})
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_CURRENT_BINARY_DIR})
-endif ()
+endif()
 
 # Create Extension library
 set(EXTENSION_SOURCES
@@ -87,6 +110,25 @@ set(EXTENSION_SOURCES
 
 add_library(${EXTENSION_NAME} SHARED ${EXTENSION_SOURCES})
 
+if(DEFINED ${EXTENSION_NAME}_CMAKE_ONLY_BUILD)
+    add_custom_command(
+        TARGET odbc_scanner
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy
+            $<TARGET_FILE:${EXTENSION_NAME}>
+            ${CMAKE_CURRENT_BINARY_DIR}/${EXTENSION_NAME}.duckdb_extension
+        COMMAND ${CMAKE_COMMAND}
+            -DABI_TYPE=C_STRUCT
+            -DEXTENSION=${CMAKE_CURRENT_BINARY_DIR}/odbc_scanner.duckdb_extension
+            -DPLATFORM_FILE=${DuckDB_BINARY_DIR}/duckdb_platform_out
+            -DVERSION_FIELD=v${TARGET_DUCKDB_VERSION_MAJOR}.${TARGET_DUCKDB_VERSION_MINOR}.${TARGET_DUCKDB_VERSION_PATCH}
+            -DEXTENSION_VERSION=${${EXTENSION_NAME}_GIT_COMMIT_HASH}
+            -DNULL_FILE=${DUCKDB_MODULE_BASE_DIR}/scripts/null.txt
+            -P ${DUCKDB_MODULE_BASE_DIR}/scripts/append_metadata.cmake
+        DEPENDS duckdb_platform
+    )
+endif()
+
 # Hide symbols
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_C_VISIBILITY_PRESET hidden)
@@ -96,7 +138,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -s")
 elseif (APPLE)
     set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} -Wl,-x")
-endif ()
+endif()
 
 target_include_directories(${EXTENSION_NAME} PRIVATE
     third_party/utf8cpp
@@ -105,7 +147,7 @@ target_include_directories(${EXTENSION_NAME} PRIVATE
     src/include
 )
 
-if (NOT MSVC)
+if(NOT MSVC)
     target_compile_options(${EXTENSION_NAME} PRIVATE
         -Wall
         -Werror
@@ -115,8 +157,8 @@ if (NOT MSVC)
         target_compile_options(${EXTENSION_NAME} PRIVATE
             -O0
         )
-    endif ()
-else ()
+    endif()
+else()
     target_compile_options(${EXTENSION_NAME} PRIVATE
         /W4
         /WX
@@ -124,22 +166,22 @@ else ()
     target_compile_definitions(${EXTENSION_NAME} PRIVATE
         -D_CRT_SECURE_NO_WARNINGS
     )
-endif ()
+endif()
 
 target_link_libraries(${EXTENSION_NAME} PRIVATE
   ${ODBC_LIBRARIES}
 )
 
-SET (CAPI_ERROR_MSG "C API test suite is disabled, to enable it specify DuckDB shared library in 'DUCKDB_CAPI_LIB_PATH' environment variable.")
+SET(CAPI_ERROR_MSG "C API test suite is disabled, to enable it specify DuckDB shared library in 'DUCKDB_CAPI_LIB_PATH' environment variable.")
 
-if (ENABLE_C_API_TESTS)
+if(ENABLE_C_API_TESTS)
     message(STATUS "C API test suite is enabled using shared lib: $ENV{DUCKDB_CAPI_LIB_PATH}")
 
-    if (NOT DEFINED ENV{DUCKDB_CAPI_LIB_PATH} OR NOT EXISTS $ENV{DUCKDB_CAPI_LIB_PATH})
+    if(NOT DEFINED ENV{DUCKDB_CAPI_LIB_PATH} OR NOT EXISTS $ENV{DUCKDB_CAPI_LIB_PATH})
         message(FATAL_ERROR ${CAPI_ERROR_MSG})
-    endif ()
+    endif()
 
     add_subdirectory(test)
-else ()
+else()
     message(STATUS ${CAPI_ERROR_MSG})
-endif ()
+endif()


### PR DESCRIPTION
This PR adds support for building `odbc_scanner` from `duckdb/duckdb` repo along with other extensions using `EXTENSION_CONFIGS` file.

Added support should not affect normal Pyton-enabled builds that are initiated from `Makefile`.

Ref: duckdblabs/duckdb-internal#7185