### PR TITLE
Allow to specify conn string directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,12 +282,17 @@ SELECT * FROM odbc_list_drivers()
 ```sql
 odbc_query(conn_handle BIGINT, query VARCHAR[, <optional named parameters>]) -> TABLE
 ```
+```sql
+odbc_query(conn_string VARCHAR, query VARCHAR[, <optional named parameters>]) -> TABLE
+```
 
 Runs specified query in a remote DBMS and returns the query results table.
 
 #### Parameters:
 
- - `conn_handle` (`BIGINT`): ODBC connection handle created with [odbc_connect](#odbc_connect)
+ - `conn_handle_or_string` (`BIGINT` or `VARCHAR`), one of:
+   - ODBC connection handle created with [odbc_connect](#odbc_connect)
+   - ODBC connection string, intended for for one-off queries, in this case new ODBC connection will be opened and will be closed automatically after the query is complete
  - `query` (`VARCHAR`): SQL query, passed to the remote DBMS
 
 Optional named parameters that can be used to pass query parameters:

--- a/src/include/connection.hpp
+++ b/src/include/connection.hpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <string>
 
+#include "duckdb_extension_api.hpp"
 #include "odbc_api.hpp"
 
 namespace odbcscanner {
@@ -24,6 +25,8 @@ enum class DbmsDriver {
 	GENERIC
 };
 
+struct ExtractedConnection;
+
 struct OdbcConnection {
 	SQLHANDLE env = nullptr;
 	SQLHANDLE dbc = nullptr;
@@ -37,6 +40,18 @@ struct OdbcConnection {
 
 	OdbcConnection &operator=(const OdbcConnection &) = delete;
 	OdbcConnection &operator=(OdbcConnection &&other) = delete;
+
+	static ExtractedConnection ExtractOrOpen(const std::string &function_name, duckdb_value conn_id_or_str_val);
+};
+
+struct ExtractedConnection {
+	int64_t id = -1;
+	std::unique_ptr<OdbcConnection> ptr;
+	bool must_be_closed = false;
+
+	ExtractedConnection(int64_t id_in, std::unique_ptr<OdbcConnection> ptr_in, bool must_be_closed_in)
+	    : id(id_in), ptr(std::move(ptr_in)), must_be_closed(std::move(must_be_closed_in)) {
+	}
 };
 
 } // namespace odbcscanner

--- a/test/sql/duckdb/direct_conn_string.test
+++ b/test/sql/duckdb/direct_conn_string.test
@@ -1,0 +1,22 @@
+# name: test/sql/duckdb/direct_conn_string.test
+# description: testing support for one-off connections in odbc_query() and odbc_copy_from()
+# group: [duckdb_direct_conn_string]
+
+require odbc_scanner
+
+query II
+SELECT * FROM odbc_query('Driver={DuckDB Driver};', 'SELECT 42, ''foo'' UNION ALL SELECT 43, ''bar'' ORDER BY 1')
+----
+42	foo
+43	bar
+
+query II
+SELECT completed, records_inserted FROM odbc_copy_from('Driver={DuckDB Driver};', 'duckdb_test_copy_from',
+  create_table=TRUE,
+  source_queries=[
+    'CREATE TABLE copy_test_basic(col1 SMALLINT, col2 INTEGER)',
+    'INSERT INTO copy_test_basic VALUES (41, 42), (43, 44)',
+    'SELECT * FROM copy_test_basic'
+    ])
+----
+1	2

--- a/test/sql/duckdb/query_basic.test
+++ b/test/sql/duckdb/query_basic.test
@@ -25,9 +25,14 @@ SELECT * FROM odbc_query(getvariable('fail'), 'SELECT 42')
 Binder Error: 'odbc_query' error: specified ODBC connection must be not NULL
 
 statement error
-SELECT * FROM odbc_query(42, 'SELECT 42')
+SELECT * FROM odbc_query(42::BIGINT, 'SELECT 42')
 ----
 Binder Error: 'odbc_query' error: ODBC connection not found on bind, id: 42
+
+statement error
+SELECT * FROM odbc_query(42::FLOAT, 'SELECT 42')
+----
+Binder Error: 'odbc_query' error: invalid first argument specified, type ID: 10
 
 statement ok
 SET VARIABLE conn = odbc_connect('ODBCSCANNER_DEBUG_CONN_STRING_ENV_VAR=ODBC_CONN_STRING')


### PR DESCRIPTION
This PR adds a shorthand syntax to `odbc_query` and `odbc_copy_from` functions allowing to specify the ODBC connection string as the first argument instead of the connection handle.

In this case one-off connection will be opened for this query and will be closed after the query is complete.

Example:

```sql
FROM odbc_query(
    'Driver={Oracle Driver};DBQ=//127.0.0.1:1521/XE;UID=scott;PWD=tiger;',
    'SELECT 42 FROM dual');
```

It is equivalent to:

```sql
FROM odbc_query(
    odbc_connect('Driver={Oracle Driver};DBQ=//127.0.0.1:1521/XE;UID=scott;PWD=tiger;'),
    'SELECT 42 FROM dual',
    close_connection=TRUE);
```

Testing: new test added (runs with DuckDB ODBC destination) that checks direct conn string mode.

Fixes: #112