### PR TITLE
odbc_copy_from: support specifying dest_query

### DIFF
--- a/src/functions/odbc_copy_from.cpp
+++ b/src/functions/odbc_copy_from.cpp
@@ -51,11 +51,12 @@ struct InsertOptions {
 	bool use_insert_all = false;
 	bool insert_in_transaction = false;
 	uint64_t max_records_in_transaction = 0;
+	std::string dest_query;
 
 	InsertOptions(uint32_t batch_size_in, bool use_insert_all_in, bool insert_in_transaction_in,
-	              uint64_t max_records_in_transaction_in)
+	              uint64_t max_records_in_transaction_in, std::string dest_query_in)
 	    : batch_size(batch_size_in), use_insert_all(use_insert_all_in), insert_in_transaction(insert_in_transaction_in),
-	      max_records_in_transaction(max_records_in_transaction_in) {
+	      max_records_in_transaction(max_records_in_transaction_in), dest_query(std::move(dest_query_in)) {
 	}
 };
 
@@ -388,7 +389,7 @@ static std::unordered_map<duckdb_type, std::string> ExtractTypeMapping(duckdb_va
 
 static InsertOptions ExtractInsertOptions(DbmsDriver driver, duckdb_value batch_size_val,
                                           duckdb_value use_insert_all_val, duckdb_value insert_in_transaction_val,
-                                          duckdb_value max_records_in_transaction_val) {
+                                          duckdb_value max_records_in_transaction_val, duckdb_value dest_query_val) {
 	uint32_t batch_size = InsertOptions::default_batch_size;
 	if (batch_size_val != nullptr && !duckdb_is_null_value(batch_size_val)) {
 		batch_size = duckdb_get_uint32(batch_size_val);
@@ -409,7 +410,14 @@ static InsertOptions ExtractInsertOptions(DbmsDriver driver, duckdb_value batch_
 		max_records_in_transaction = duckdb_get_uint64(max_records_in_transaction_val);
 	}
 
-	return InsertOptions(batch_size, use_insert_all, insert_in_transaction, max_records_in_transaction);
+	std::string dest_query;
+	if (dest_query_val != nullptr && !duckdb_is_null_value(dest_query_val)) {
+		auto dest_query_cstr = VarcharPtr(duckdb_get_varchar(dest_query_val), VarcharDeleter);
+		dest_query = std::string(dest_query_cstr.get());
+	}
+
+	return InsertOptions(batch_size, use_insert_all, insert_in_transaction, max_records_in_transaction,
+	                     std::move(dest_query));
 }
 
 static CreateTableOptions ExtractCreateTableOptions(DbmsDriver driver, DbmsQuirks &quirks,
@@ -473,9 +481,10 @@ static void Bind(duckdb_bind_info info) {
 	    ValuePtr(duckdb_bind_get_named_parameter(info, "insert_in_transaction"), ValueDeleter);
 	auto max_records_in_transaction_val =
 	    ValuePtr(duckdb_bind_get_named_parameter(info, "max_records_in_transaction"), ValueDeleter);
-	InsertOptions insert_options =
-	    ExtractInsertOptions(conn.driver, batch_size_val.get(), use_insert_all_val.get(),
-	                         insert_in_transaction_val.get(), max_records_in_transaction_val.get());
+	auto dest_query_val = ValuePtr(duckdb_bind_get_named_parameter(info, "dest_query"), ValueDeleter);
+	InsertOptions insert_options = ExtractInsertOptions(conn.driver, batch_size_val.get(), use_insert_all_val.get(),
+	                                                    insert_in_transaction_val.get(),
+	                                                    max_records_in_transaction_val.get(), dest_query_val.get());
 
 	auto create_table_val = ValuePtr(duckdb_bind_get_named_parameter(info, "create_table"), ValueDeleter);
 	auto column_types_val = ValuePtr(duckdb_bind_get_named_parameter(info, "column_types"), ValueDeleter);
@@ -615,6 +624,11 @@ static std::string BuildCreateTableQuery(const std::string &table_name, const st
 
 static std::string BuildInsertQuery(const std::string &table_name, const std::vector<SourceColumn> &columns,
                                     InsertOptions options, uint32_t rows_count) {
+	// query explicitly specified by user, not need to generate one
+	if (!options.dest_query.empty()) {
+		return options.dest_query;
+	}
+
 	std::string query = "INSERT ";
 
 	if (options.use_insert_all) {
@@ -987,6 +1001,7 @@ void OdbcCopyFromFunction::Register(duckdb_connection conn) {
 	duckdb_table_function_add_named_parameter(fun.get(), "use_insert_all", bool_type.get());
 	duckdb_table_function_add_named_parameter(fun.get(), "insert_in_transaction", bool_type.get());
 	duckdb_table_function_add_named_parameter(fun.get(), "max_records_in_transaction", ubigint_type.get());
+	duckdb_table_function_add_named_parameter(fun.get(), "dest_query", varchar_type.get());
 	// create table options
 	duckdb_table_function_add_named_parameter(fun.get(), "create_table", bool_type.get());
 	duckdb_table_function_add_named_parameter(fun.get(), "column_types", map_type.get());

--- a/test/sql/oracle/copy_from.test
+++ b/test/sql/oracle/copy_from.test
@@ -313,5 +313,43 @@ SELECT * FROM odbc_query(getvariable('conn'), 'SELECT * FROM "duckdb_test_copy_f
 statement ok
 SELECT * FROM odbc_query(getvariable('conn'), 'DROP TABLE "duckdb_test_copy_from"')
 
+# explicit dest query
+
+statement ok
+SELECT * FROM odbc_query(getvariable('conn'),
+  'CREATE TABLE "duckdb_test_copy_from" (
+    col1 NUMBER(10,0),
+    col2 VARCHAR2(10),
+    col3 NUMBER(10,0),
+    col4 NVARCHAR2(10)
+  )')
+
+query II
+SELECT completed, records_inserted FROM odbc_copy_from(getvariable('conn'), 'duckdb_test_copy_from',
+  create_table=FALSE,
+  batch_size=2,
+  source_queries=[
+    'CREATE TABLE copy_test_dest_query(
+      col1 INTEGER,
+      col2 VARCHAR
+    )',
+    'INSERT INTO copy_test_dest_query VALUES 
+      (42, ''foo''),
+      (43, ''🌌'')
+    ',
+    'SELECT * FROM copy_test_dest_query'
+    ],
+  dest_query='INSERT INTO "duckdb_test_copy_from" VALUES(?,?,?,?)')
+----
+1	2
+
+query IIII
+SELECT * FROM odbc_query(getvariable('conn'), 'SELECT * FROM "duckdb_test_copy_from"')
+----
+42	foo	43	🌌
+
+statement ok
+SELECT * FROM odbc_query(getvariable('conn'), 'DROP TABLE "duckdb_test_copy_from"')
+
 statement ok
 SELECT odbc_close(getvariable('conn'))


### PR DESCRIPTION
This change allows to specify the `dest_query` option to `odbc_copy_from` function to use the specified query instead of generating the `INSERT (ALL)` query.

Note, that the destination query must have the number of `?` parameter placeholders that corresponds to the source query and the batch size.

Example:

```sql
SELECT * FROM odbc_query(getvariable('conn'),
  'CREATE TABLE "duckdb_test_copy_from" (
    col1 NUMBER(10,0),
    col2 VARCHAR2(10),
    col3 NUMBER(10,0),
    col4 NVARCHAR2(10)
  )');

FROM odbc_copy_from(getvariable('conn'), 'duckdb_test_copy_from',
  create_table=FALSE,
  batch_size=2,
  source_queries=[
    'CREATE TABLE copy_test_dest_query(
      col1 INTEGER,
      col2 VARCHAR
    )',
    'INSERT INTO copy_test_dest_query VALUES
      (42, ''foo''),
      (43, ''🌌'')
    ',
    'SELECT * FROM copy_test_dest_query'
    ],
  dest_query='INSERT INTO "duckdb_test_copy_from" VALUES(?,?,?,?)');
```

Fixes: #115