### PR TITLE
Support UID and PWD as parameters to odbc_connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,13 @@ SELECT odbc_commit(getvariable('conn'))
 ```sql
 odbc_connect(conn_string VARCHAR) -> BIGINT
 ```
+```sql
+odbc_connect(conn_string VARCHAR, username VARCHAR, password VARCHAR) -> BIGINT
+```
 
 Opens an ODBC connection to a remote DBMS.
+
+If `username` and `password` parameters are specified, they are appended to the connection string as `UID` and `PWD`.
 
 #### Parameters:
 

--- a/src/functions/odbc_connect.cpp
+++ b/src/functions/odbc_connect.cpp
@@ -23,28 +23,75 @@ static void odbc_connect_function(duckdb_function_info info, duckdb_data_chunk i
 
 namespace odbcscanner {
 
+static void AppendUsernameAndPassword(duckdb_data_chunk input, std::string &conn_str) {
+	auto username_pair = Types::ExtractFunctionArg<std::string>(input, 1);
+	if (username_pair.second) {
+		throw ScannerException("'odbc_connect' error: specified username argument must be not NULL");
+	}
+	std::string username = username_pair.first;
+
+	auto password_pair = Types::ExtractFunctionArg<std::string>(input, 2);
+	if (password_pair.second) {
+		throw ScannerException("'odbc_connect' error: specified password argument must be not NULL");
+	}
+	std::string password = password_pair.first;
+
+	std::string conn_str_upper = Strings::ToUpper(conn_str);
+	if (conn_str_upper.find("UID") != std::string::npos) {
+		throw ScannerException("'odbc_connect' error: username (UID) cannot be specified in both connection string and "
+		                       "a separate argument");
+	}
+	if (conn_str_upper.find("PWD") != std::string::npos) {
+		throw ScannerException("'odbc_connect' error: password (PWD) cannot be specified in both connection string and "
+		                       "a separate argument");
+	}
+
+	if (conn_str.length() == 0 || conn_str.at(conn_str.length() - 1) != ';') {
+		conn_str.append(";");
+	}
+	conn_str.append("UID=");
+	conn_str.append(username);
+	conn_str.append(";");
+
+	conn_str.append("PWD=");
+	conn_str.append(password);
+	conn_str.append(";");
+}
+
 static void Connect(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output) {
 	(void)info;
 
-	auto arg = Types::ExtractFunctionArg<std::string>(input, 0);
-	if (arg.second) {
-		throw ScannerException("'odbc_connect' error: specified URL argument must be not NULL");
+	idx_t args_count = duckdb_data_chunk_get_column_count(input);
+
+	if (args_count != 1 && args_count != 3) {
+		throw ScannerException(
+		    "'odbc_connect' error: invalid number of arguments specified, count: " + std::to_string(args_count) +
+		    ", supported arguments: 'odbc_connect(conn_string: VARCHAR)', 'odbc_connect(conn_string: "
+		    "VARCHAR, username: VARCHAR, password: VARCHAR)'");
 	}
 
-	std::string url = arg.first;
+	auto conn_str_pair = Types::ExtractFunctionArg<std::string>(input, 0);
+	if (conn_str_pair.second) {
+		throw ScannerException("'odbc_connect' error: specified connection string argument must be not NULL");
+	}
+	std::string conn_str = conn_str_pair.first;
+
+	if (args_count == 3) {
+		AppendUsernameAndPassword(input, conn_str);
+	}
 
 	// Env var fetch is not thread-safe, should be used only for debugging,
 	// ideally this logic should be moved into SQLLogic test runner.
-	if (url.rfind(ODBCSCANNER_DEBUG_CONN_STRING_ENV_VAR, 0) == 0 && url.find(";") == std::string::npos) {
-		std::vector<std::string> parts = Strings::Split(url, '=');
+	if (conn_str.rfind(ODBCSCANNER_DEBUG_CONN_STRING_ENV_VAR, 0) == 0 && conn_str.find(";") == std::string::npos) {
+		std::vector<std::string> parts = Strings::Split(conn_str, '=');
 		if (parts.size() == 2 && ODBCSCANNER_DEBUG_CONN_STRING_ENV_VAR == parts.at(0)) {
 			std::string &var_name = parts.at(1);
 			char *var = std::getenv(var_name.c_str());
-			url = var != nullptr ? std::string(var) : "Driver={DuckDB Driver};";
+			conn_str = var != nullptr ? std::string(var) : "Driver={DuckDB Driver};";
 		}
 	}
 
-	auto oc_ptr = std_make_unique<OdbcConnection>(url);
+	auto oc_ptr = std_make_unique<OdbcConnection>(conn_str);
 
 	int64_t *result_data = reinterpret_cast<int64_t *>(duckdb_vector_get_data(output));
 	result_data[0] = ConnectionsRegistry::Add(std::move(oc_ptr));
@@ -57,7 +104,7 @@ void OdbcConnectFunction::Register(duckdb_connection conn) {
 	// parameters and return
 	auto varchar_type = LogicalTypePtr(duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR), LogicalTypeDeleter);
 	auto bigint_type = LogicalTypePtr(duckdb_create_logical_type(DUCKDB_TYPE_BIGINT), LogicalTypeDeleter);
-	duckdb_scalar_function_add_parameter(fun.get(), varchar_type.get());
+	duckdb_scalar_function_set_varargs(fun.get(), varchar_type.get());
 	duckdb_scalar_function_set_return_type(fun.get(), bigint_type.get());
 
 	// callbacks

--- a/src/include/strings.hpp
+++ b/src/include/strings.hpp
@@ -14,6 +14,8 @@ struct Strings {
 	static std::vector<std::string> Split(const std::string &str, char delim);
 
 	static std::string ReplaceAll(std::string &str, const std::string &snippet, const std::string &replacement);
+
+	static std::string ToUpper(const std::string &str);
 };
 
 } // namespace odbcscanner

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -39,4 +39,11 @@ std::string Strings::ReplaceAll(std::string &str, const std::string &snippet, co
 	return str;
 }
 
+std::string Strings::ToUpper(const std::string &str) {
+	std::string copy(str);
+	std::transform(copy.begin(), copy.end(), copy.begin(),
+	               [](unsigned char c) { return static_cast<char>(std::toupper(static_cast<int>(c))); });
+	return (copy);
+}
+
 } // namespace odbcscanner

--- a/test/sql/connect.test
+++ b/test/sql/connect.test
@@ -12,12 +12,12 @@ require odbc_scanner
 statement error
 SET VARIABLE conn = odbc_connect()
 ----
-Binder Error: No function matches the given name and argument types 'odbc_connect()'
+invalid number of arguments specified
 
 statement error
 SET VARIABLE conn = odbc_connect(NULL)
 ----
-Invalid Input Error: 'odbc_connect' error: specified URL argument must be not NULL
+Invalid Input Error: 'odbc_connect' error: specified connection string argument must be not NULL
 
 statement error
 SET VARIABLE conn = odbc_connect('fail')
@@ -28,6 +28,31 @@ statement error
 SET VARIABLE conn = odbc_connect('Driver=fail')
 ----
 Invalid Input Error: 'SQLDriverConnect' failed
+
+statement error
+SET VARIABLE conn = odbc_connect('Driver=fail', 'foo')
+----
+invalid number of arguments specified
+
+statement error
+SET VARIABLE conn = odbc_connect('Driver=fail', NULL, 'bar')
+----
+'odbc_connect' error: specified username argument must be not NULL
+
+statement error
+SET VARIABLE conn = odbc_connect('Driver=fail;uid=foo;Pwd=bar')
+----
+'SQLDriverConnect' failed, connection string: 'Driver=fail;UID=***;PWD=***'
+
+statement error
+SET VARIABLE conn = odbc_connect('Driver=fail', 'foo', 'bar')
+----
+'SQLDriverConnect' failed, connection string: 'Driver=fail;UID=***;PWD=***;'
+
+statement error
+SET VARIABLE conn = odbc_connect('Driver=fail;', 'foo', 'bar')
+----
+'SQLDriverConnect' failed, connection string: 'Driver=fail;UID=***;PWD=***;'
 
 statement ok
 SET VARIABLE conn = odbc_connect('ODBCSCANNER_DEBUG_CONN_STRING_ENV_VAR=ODBC_CONN_STRING')


### PR DESCRIPTION
This PR adds an overload to `odbc_connect` function allowing to pass username and password as a second and third parameters. Specified username and password are appended to the connection string as `UID` and `PWD`.

Example:

```sql
SET VARIABLE conn = odbc_connect('Driver=...;', 'scott', 'tiger');
```

Fixes: #120