### PR TITLE
Handle SQL_NO_DATA in SQLExecute

### DIFF
--- a/src/functions/odbc_copy_from.cpp
+++ b/src/functions/odbc_copy_from.cpp
@@ -1015,7 +1015,7 @@ static void CopyInTransaction(duckdb_function_info info, duckdb_data_chunk outpu
 
 			{
 				SQLRETURN ret = SQLExecute(ctx.hstmt());
-				if (!SQL_SUCCEEDED(ret)) {
+				if (!SQL_SUCCEEDED(ret) && ret != SQL_NO_DATA) {
 					std::string diag = Diagnostics::Read(ctx.hstmt(), SQL_HANDLE_STMT);
 					throw ScannerException("'SQLExecute' failed, query: '" + ctx.query +
 					                       "', return: " + std::to_string(ret) + ", diagnostics: '" + diag + "'");

--- a/src/functions/odbc_query.cpp
+++ b/src/functions/odbc_query.cpp
@@ -281,7 +281,7 @@ static SqlExecStatus BindParamsAndExecute(BindData &bdata) {
 
 	{
 		SQLRETURN ret = SQLExecute(ctx.hstmt());
-		if (!SQL_SUCCEEDED(ret)) {
+		if (!SQL_SUCCEEDED(ret) && ret != SQL_NO_DATA) {
 			if (bdata.query_options.ignore_exec_failure) {
 				return SqlExecStatus::FAILURE;
 			}

--- a/test/test_common.cpp
+++ b/test/test_common.cpp
@@ -325,6 +325,14 @@ std::string CastAsDecimalSQL(const std::string &value, uint8_t precision, uint8_
 	return "CAST(" + value + " AS " + type_name + ") " + alias + postfix;
 }
 
+std::string IfExistsSQL() {
+	if (DBMSConfigured("Oracle")) {
+		return "";
+	} else {
+		return "IF EXISTS";
+	}
+}
+
 #if defined(__linux__)
 static std::string CurrentExecutablePathLinux() {
 	std::string res;

--- a/test/test_common.hpp
+++ b/test/test_common.hpp
@@ -72,4 +72,6 @@ std::string CastAsDateSQL(const std::string& value, const std::string &alias = "
 
 std::string CastAsDecimalSQL(const std::string& value, uint8_t precision, uint8_t scale, const std::string &alias = "");
 
+std::string IfExistsSQL();
+
 std::string ProjectRootDir();


### PR DESCRIPTION
This change accepts `SQL_NO_DATA` as a valid return code from `SQLExecute` call, according to ODBC spec:

> If SQLExecute executes a searched update, insert, or delete statement that does not affect any rows at the data source, the call to SQLExecute returns SQL_NO_DATA.

Testing: new test added that covers `odbc_query`.

Fixes: #123