### PR TITLE
Enable columns binding only for Oracle and DB2

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Installed version (commit ID) can be checked using the following query:
 SELECT * FROM duckdb_extensions() WHERE extension_name = 'odbc_scanner';
 ```
 
+To install a version built from a specific commit run:
+
+```sql
+FORCE INSTALL 'http://nightly-extensions.duckdb.org/odbc_scanner/<7_chars_commit_id>/v1.2.0/<platform>/odbc_scanner.duckdb_extension.gz';
+```
+
 ## Usage example
 
 ```sql
@@ -311,8 +317,6 @@ Optional named parameters that can change types mapping:
 
  - `decimal_columns_as_chars` (`BOOLEAN`, default: `false`): read `DECIMAL` values as `VARCHAR`s that are parsed back into `DECIMAL`s before returning them to client
  - `decimal_columns_precision_through_ard` (`BOOLEAN`, default: `false`): when reading a `DECIMAL` specify its `precision` and `scale` through "Application Row Descriptor"
- - `decimal_columns_precision_through_ard_bind` (`BOOLEAN`, default: `false`) allow binding a `DECIMAL` column to a result buffer when its `precision` and `scale` are specified through "Application Row Descriptor"
- - `decimal_params_as_chars` (`BOOLEAN`, default: `false`): pass `DECIMAL` parameters as `VARCHAR`s
  - `integral_params_as_decimals` (`BOOLEAN`, default: `false`): pass (unsigned) `TINYINT`, `SMALLINT`, `INTEGER` and `BIGINT` parameters as `SQL_C_NUMERIC`.
  - `reset_stmt_before_execute` (`BOOLEAN`, default: `false`): reset the prepared statement (using `SQLFreeStmt(h, SQL_CLOSE)`) before executing it
  - `time_params_as_ss_time2` (`BOOLEAN`, default: `false`): pass `TIME` parameters as SQL Server's `TIME2` values
@@ -323,6 +327,7 @@ Optional named parameters that can change types mapping:
  - `timestamptz_params_as_ss_timestampoffset` (`BOOLEAN`, default: `false`): pass `TIMESTAMP_TZ` parameters as SQL Server's `DATETIMEOFFSET`
  - `var_len_data_single_part` (`BOOLEAN`, default: `false`): read long `VARCHAR` or `VARBINARY` values as a single read (used when a driver does not support [Retrieving Variable-Length Data in Parts](https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgetdata-function?view=sql-server-ver17#retrieving-variable-length-data-in-parts))
  - `var_len_params_long_threshold_bytes` (`UINTEGER`, default: `4000`): a length threshold after that `SQL_WVARCHAR` parameters are passed as `SQL_WLONGVARCHAR`
+ - `enable_columns_binding` (`BOOLEAN`, default: `false`): whether to allow using `SQLBindCol` instead of `SQLGetData` for fixed-size columns
 
 Other optional named parameters:
 

--- a/src/dbms_quirks.cpp
+++ b/src/dbms_quirks.cpp
@@ -12,9 +12,9 @@ DbmsQuirks::DbmsQuirks(OdbcConnection &conn, const std::map<std::string, ValuePt
 	case DbmsDriver::ORACLE:
 		this->var_len_params_long_threshold_bytes = 4000;
 		this->decimal_columns_precision_through_ard = true;
-		this->decimal_columns_precision_through_ard_bind = true;
 		this->integral_params_as_decimals = true;
 		this->timestamp_columns_with_typename_date_as_date = true;
+		this->enable_columns_binding = true;
 		break;
 	case DbmsDriver::MSSQL:
 		this->var_len_params_long_threshold_bytes = 8000;
@@ -27,6 +27,7 @@ DbmsQuirks::DbmsQuirks(OdbcConnection &conn, const std::map<std::string, ValuePt
 	case DbmsDriver::DB2:
 		this->decimal_params_as_chars = true;
 		this->decimal_columns_as_chars = true;
+		this->enable_columns_binding = true;
 		break;
 
 	case DbmsDriver::MARIADB:
@@ -72,8 +73,6 @@ DbmsQuirks::DbmsQuirks(OdbcConnection &conn, const std::map<std::string, ValuePt
 			this->timestamp_columns_as_timestamp_ns = duckdb_get_bool(val.get());
 		} else if (en.first == "decimal_columns_precision_through_ard") {
 			this->decimal_columns_precision_through_ard = duckdb_get_bool(val.get());
-		} else if (en.first == "decimal_columns_precision_through_ard_bind") {
-			this->decimal_columns_precision_through_ard_bind = duckdb_get_bool(val.get());
 		} else if (en.first == "decimal_params_as_chars") {
 			this->decimal_params_as_chars = duckdb_get_bool(val.get());
 		} else if (en.first == "integral_params_as_decimals") {
@@ -102,8 +101,8 @@ DbmsQuirks::DbmsQuirks(OdbcConnection &conn, const std::map<std::string, ValuePt
 		} else if (en.first == "var_len_params_long_threshold_bytes") {
 			uint32_t num = duckdb_get_uint32(val.get());
 			this->var_len_params_long_threshold_bytes = num;
-		} else if (en.first == "timestamp_columns_as_timestamp_ns") {
-			this->timestamp_columns_as_timestamp_ns = duckdb_get_bool(val.get());
+		} else if (en.first == "enable_columns_binding") {
+			this->enable_columns_binding = duckdb_get_bool(val.get());
 		} else {
 			throw ScannerException("Unsupported user option: '" + en.first + "'");
 		}
@@ -114,7 +113,6 @@ const std::vector<std::string> DbmsQuirks::AllNames() {
 	std::vector<std::string> res;
 	res.emplace_back("decimal_columns_as_chars");
 	res.emplace_back("decimal_columns_precision_through_ard");
-	res.emplace_back("decimal_columns_precision_through_ard_bind");
 	res.emplace_back("decimal_params_as_chars");
 	res.emplace_back("integral_params_as_decimals");
 	res.emplace_back("reset_stmt_before_execute");
@@ -126,6 +124,7 @@ const std::vector<std::string> DbmsQuirks::AllNames() {
 	res.emplace_back("timestamptz_params_as_ss_timestampoffset");
 	res.emplace_back("var_len_data_single_part");
 	res.emplace_back("var_len_params_long_threshold_bytes");
+	res.emplace_back("enable_columns_binding");
 	return res;
 }
 

--- a/src/functions/odbc_query.cpp
+++ b/src/functions/odbc_query.cpp
@@ -421,7 +421,6 @@ void OdbcQueryFunction::Register(duckdb_connection conn) {
 	// quirks
 	duckdb_table_function_add_named_parameter(fun.get(), "decimal_columns_as_chars", bool_type.get());
 	duckdb_table_function_add_named_parameter(fun.get(), "decimal_columns_precision_through_ard", bool_type.get());
-	duckdb_table_function_add_named_parameter(fun.get(), "decimal_columns_precision_through_ard_bind", bool_type.get());
 	duckdb_table_function_add_named_parameter(fun.get(), "decimal_params_as_chars", bool_type.get());
 	duckdb_table_function_add_named_parameter(fun.get(), "integral_params_as_decimals", bool_type.get());
 	duckdb_table_function_add_named_parameter(fun.get(), "reset_stmt_before_execute", bool_type.get());
@@ -434,6 +433,7 @@ void OdbcQueryFunction::Register(duckdb_connection conn) {
 	duckdb_table_function_add_named_parameter(fun.get(), "timestamptz_params_as_ss_timestampoffset", bool_type.get());
 	duckdb_table_function_add_named_parameter(fun.get(), "var_len_data_single_part", bool_type.get());
 	duckdb_table_function_add_named_parameter(fun.get(), "var_len_params_long_threshold_bytes", uint_type.get());
+	duckdb_table_function_add_named_parameter(fun.get(), "enable_columns_binding", bool_type.get());
 
 	// callbacks
 	duckdb_table_function_set_bind(fun.get(), odbc_query_bind);

--- a/src/include/dbms_quirks.hpp
+++ b/src/include/dbms_quirks.hpp
@@ -14,7 +14,6 @@ struct DbmsQuirks {
 
 	bool decimal_columns_as_chars = false;
 	bool decimal_columns_precision_through_ard = false;
-	bool decimal_columns_precision_through_ard_bind = false;
 	bool decimal_params_as_chars = false;
 	bool integral_params_as_decimals = false;
 	bool reset_stmt_before_execute = false;
@@ -26,6 +25,7 @@ struct DbmsQuirks {
 	bool timestamptz_params_as_ss_timestampoffset = false;
 	bool var_len_data_single_part = false;
 	uint32_t var_len_params_long_threshold_bytes = 4000;
+	bool enable_columns_binding = false;
 
 	explicit DbmsQuirks(OdbcConnection &conn, const std::map<std::string, ValuePtr> &user_quirks);
 

--- a/src/include/odbc_api.hpp
+++ b/src/include/odbc_api.hpp
@@ -17,6 +17,10 @@ extern "C" {
 
 namespace odbcscanner {
 
+struct SqlBit {
+	SQLCHAR val = 0;
+};
+
 using EnvHandlePtr = std::unique_ptr<void, void (*)(SQLHANDLE)>;
 
 inline void EnvHandleDeleter(SQLHANDLE env) {

--- a/src/include/params.hpp
+++ b/src/include/params.hpp
@@ -18,6 +18,7 @@ namespace odbcscanner {
 struct Params {
 	static const param_type TYPE_DECIMAL_AS_CHARS = DUCKDB_TYPE_DECIMAL + 1000;
 	static const param_type TYPE_TIME_WITH_NANOS = DUCKDB_TYPE_TIME + 1000;
+	static const param_type TYPE_SQL_BIT = DUCKDB_TYPE_BOOLEAN + 1000;
 
 	static std::vector<ScannerValue> Extract(DbmsQuirks &quirks, duckdb_data_chunk chunk, idx_t col_idx);
 

--- a/src/include/scanner_value.hpp
+++ b/src/include/scanner_value.hpp
@@ -44,6 +44,7 @@ class ScannerValue {
 		SQL_TIME_STRUCT time;
 		SQL_SS_TIME2_STRUCT time_with_nanos;
 		SQL_TIMESTAMP_STRUCT timestamp;
+		SqlBit sql_bit;
 
 		InternalValue() : null_val(true) {
 		}
@@ -87,6 +88,8 @@ class ScannerValue {
 		}
 		InternalValue(SQL_TIMESTAMP_STRUCT value) : timestamp(value) {
 		}
+		InternalValue(SqlBit value) : sql_bit(value) {
+		}
 
 		InternalValue(InternalValue &other) = delete;
 		InternalValue(InternalValue &&other) = delete;
@@ -120,6 +123,7 @@ public:
 	explicit ScannerValue(SQL_DATE_STRUCT value);
 	explicit ScannerValue(duckdb_time_struct value, bool use_time_with_nanos);
 	explicit ScannerValue(TimestampNsStruct value);
+	explicit ScannerValue(SqlBit value);
 
 	ScannerValue(ScannerValue &other) = delete;
 	ScannerValue(ScannerValue &&other);

--- a/src/scanner_value.cpp
+++ b/src/scanner_value.cpp
@@ -136,6 +136,12 @@ SQL_TIMESTAMP_STRUCT &ScannerValue::Value<SQL_TIMESTAMP_STRUCT>() {
 	return val.timestamp;
 }
 
+template <>
+SqlBit &ScannerValue::Value<SqlBit>() {
+	CheckType(Params::TYPE_SQL_BIT);
+	return val.sql_bit;
+}
+
 ScannerValue::ScannerValue() : type_id(DUCKDB_TYPE_SQLNULL), len_bytes(SQL_NULL_DATA) {
 }
 
@@ -276,6 +282,9 @@ ScannerValue::ScannerValue(TimestampNsStruct value) : type_id(DUCKDB_TYPE_TIMEST
 	this->len_bytes = sizeof(ts);
 }
 
+ScannerValue::ScannerValue(SqlBit value) : type_id(Params::TYPE_SQL_BIT), len_bytes(sizeof(value)), val(value) {
+}
+
 void ScannerValue::AssignByType(param_type type_id, InternalValue &val, ScannerValue &other) {
 	switch (type_id) {
 	case DUCKDB_TYPE_SQLNULL:
@@ -343,6 +352,9 @@ void ScannerValue::AssignByType(param_type type_id, InternalValue &val, ScannerV
 		break;
 	case DUCKDB_TYPE_TIMESTAMP:
 		val.timestamp = other.Value<SQL_TIMESTAMP_STRUCT>();
+		break;
+	case Params::TYPE_SQL_BIT:
+		val.sql_bit = other.Value<SqlBit>();
 		break;
 	default:
 		throw ScannerException("Unsupported assign value type, ID: " + std::to_string(type_id));

--- a/src/types/float_types.cpp
+++ b/src/types/float_types.cpp
@@ -74,7 +74,7 @@ static void FetchAndSetResultInternal(QueryContext &ctx, SQLSMALLINT ctype, Odbc
 	SQLRETURN ret = SQLGetData(ctx.hstmt(), col_idx, ctype, &fetched, sizeof(fetched), &ind);
 	if (!SQL_SUCCEEDED(ret)) {
 		std::string diag = Diagnostics::Read(ctx.hstmt(), SQL_HANDLE_STMT);
-		throw ScannerException("'SQLGetData' for failed, C type: " + std::to_string(ctype) + ", column index: " +
+		throw ScannerException("'SQLGetData' failed, C type: " + std::to_string(ctype) + ", column index: " +
 		                       std::to_string(col_idx) + ", column type: " + odbc_type.ToString() + ",  query: '" +
 		                       ctx.query + "', return: " + std::to_string(ret) + ", diagnostics: '" + diag + "'");
 	}

--- a/src/types/integer_types.cpp
+++ b/src/types/integer_types.cpp
@@ -230,7 +230,7 @@ static void FetchAndSetResultInternal(QueryContext &ctx, SQLSMALLINT ctype, Odbc
 	SQLRETURN ret = SQLGetData(ctx.hstmt(), col_idx, ctype, &fetched, sizeof(fetched), &ind);
 	if (!SQL_SUCCEEDED(ret)) {
 		std::string diag = Diagnostics::Read(ctx.hstmt(), SQL_HANDLE_STMT);
-		throw ScannerException("'SQLGetData' for failed, C type: " + std::to_string(ctype) + ", column index: " +
+		throw ScannerException("'SQLGetData' failed, C type: " + std::to_string(ctype) + ", column index: " +
 		                       std::to_string(col_idx) + ", column type: " + odbc_type.ToString() + ",  query: '" +
 		                       ctx.query + "', return: " + std::to_string(ret) + ", diagnostics: '" + diag + "'");
 	}

--- a/test/sql/db2/11_date.test
+++ b/test/sql/db2/11_date.test
@@ -29,6 +29,16 @@ SELECT column_type from (
 ----
 DATE
 
+query II
+SELECT * FROM odbc_query(getvariable('conn'), 'SELECT CAST(42 AS INT), CAST(''2020-12-31'' AS DATE) FROM sysibm.sysdummy1')
+----
+42	2020-12-31
+
+query II
+SELECT * FROM odbc_query(getvariable('conn'), 'SELECT CAST(''2020-12-31'' AS DATE), CAST(42 AS INT) FROM sysibm.sysdummy1')
+----
+2020-12-31	42
+
 query I
 SELECT * FROM odbc_query(getvariable('conn'), 'SELECT CAST(? AS DATE) FROM sysibm.sysdummy1', params=row('2020-12-31'::DATE))
 ----

--- a/test/sql/duckdb/user_quirks.test
+++ b/test/sql/duckdb/user_quirks.test
@@ -13,7 +13,6 @@ SELECT * FROM odbc_query(
   'SELECT 42',
 	decimal_columns_as_chars=TRUE,
 	decimal_columns_precision_through_ard=TRUE,
-	decimal_columns_precision_through_ard_bind=TRUE,
 	decimal_params_as_chars=TRUE,
 	integral_params_as_decimals=TRUE,
 	reset_stmt_before_execute=TRUE,
@@ -25,7 +24,7 @@ SELECT * FROM odbc_query(
 	timestamptz_params_as_ss_timestampoffset=TRUE,
 	var_len_data_single_part=TRUE,
 	var_len_params_long_threshold_bytes=42,
-	timestamp_columns_as_timestamp_ns=TRUE
+	enable_columns_binding=TRUE
 )
 
 statement error

--- a/test/sql/mssql/05_bit.test
+++ b/test/sql/mssql/05_bit.test
@@ -24,6 +24,23 @@ SELECT column_type from (
 ----
 BOOLEAN
 
+query II
+SELECT * FROM odbc_query(getvariable('conn'), 'SELECT CAST(42 AS INT), CAST(1 AS BIT)')
+----
+42	1
+
+statement error
+SELECT * FROM odbc_query(getvariable('conn'), 'SELECT CAST(42 AS INT), CAST(1 AS BIT)',
+  enable_columns_binding=TRUE)
+----
+Invalid Descriptor Index
+
+query II
+SELECT * FROM odbc_query(getvariable('conn'), 'SELECT CAST(0 AS BIT), CAST(1 AS BIT)',
+  enable_columns_binding=TRUE)
+----
+0	1
+
 query I
 SELECT * FROM odbc_query(getvariable('conn'), 'SELECT CAST(? AS BIT)', params=row(TRUE))
 ----

--- a/test/sql/mssql/12_date.test
+++ b/test/sql/mssql/12_date.test
@@ -19,6 +19,16 @@ SELECT column_type from (
 ----
 DATE
 
+query II
+SELECT * FROM odbc_query(getvariable('conn'), 'SELECT CAST(42 AS INT), CAST(''2020-12-31'' AS DATE)')
+----
+42	2020-12-31
+
+query II
+SELECT * FROM odbc_query(getvariable('conn'), 'SELECT CAST(''2020-12-31'' AS DATE), CAST(42 AS INT)')
+----
+2020-12-31	42
+
 query I
 SELECT * FROM odbc_query(getvariable('conn'), 'SELECT CAST(? AS DATE)', params=row('2020-12-31'::DATE))
 ----

--- a/test/sql/oracle/03_number.test
+++ b/test/sql/oracle/03_number.test
@@ -26,6 +26,16 @@ SELECT column_type from (
 ----
 DECIMAL(4,3)
 
+query II
+SELECT * FROM odbc_query(getvariable('conn'), 'SELECT CAST(42 AS INT), CAST(''1.234'' AS NUMBER(4,3)) FROM dual')
+----
+42	1.234
+
+query II
+SELECT * FROM odbc_query(getvariable('conn'), 'SELECT CAST(''1.234'' AS NUMBER(4,3)), CAST(42 AS INT) FROM dual')
+----
+1.234	42
+
 query I
 SELECT * FROM odbc_query(getvariable('conn'), 'SELECT CAST(''123456.789'' AS NUMBER(9,3)) FROM dual')
 ----

--- a/test/sql/oracle/06_date.test
+++ b/test/sql/oracle/06_date.test
@@ -29,6 +29,11 @@ SELECT column_type from (
 ----
 DATE
 
+query II
+SELECT * FROM odbc_query(getvariable('conn'), 'SELECT CAST(42 AS INT), to_date(''2020-12-31'', ''YYYY-MM-DD'') FROM dual')
+----
+42	2020-12-31
+
 query I
 SELECT * FROM odbc_query(getvariable('conn'), 'SELECT CAST(? AS DATE) FROM dual', params=row('2020-12-31'::DATE))
 ----

--- a/test/test_common.cpp
+++ b/test/test_common.cpp
@@ -190,6 +190,12 @@ double Result::Value<double>(idx_t col_idx, idx_t row_idx) {
 }
 
 template <>
+bool Result::Value<bool>(idx_t col_idx, idx_t row_idx) {
+	bool *data = NotNullData<bool>(DUCKDB_TYPE_BOOLEAN, chunk, cur_row_idx, col_idx, row_idx);
+	return data[row_idx];
+}
+
+template <>
 std::string Result::Value<std::string>(idx_t col_idx, idx_t row_idx) {
 	duckdb_string_t *data = NotNullData<duckdb_string_t>(DUCKDB_TYPE_VARCHAR, chunk, cur_row_idx, col_idx, row_idx);
 	duckdb_string_t dstr = data[row_idx];


### PR DESCRIPTION
While `SQLBindCol` provides better retrieving performance, by ODBC spec it cannot be mixed with `SQLGetData`. At the same time it is necessary to use `SQLGetData` for [Retrieving Variable-Length Data in Parts](https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgetdata-function?view=sql-server-ver17#retrieving-variable-length-data-in-parts).

This PR adds an option `enable_columns_binding` that is intended to be used only with ODBC drivers that allow to mix `SQLBindCol` with `SQLGetData`. It is enabled by default for Oracle and DB2.

Testing: added test coverage for mixed fetches.

Fixes: #128