### PR TITLE
Stabilize Firebird timezone tests

### DIFF
--- a/test/sql/firebird/14_time_with_time_zone.test
+++ b/test/sql/firebird/14_time_with_time_zone.test
@@ -4,8 +4,6 @@
 
 require odbc_scanner
 
-require-env TIMEZONE_DISABLED
-
 statement ok
 SET VARIABLE conn = odbc_connect('ODBCSCANNER_DEBUG_CONN_STRING_ENV_VAR=ODBC_CONN_STRING')
 
@@ -23,16 +21,19 @@ SELECT * FROM odbc_query(getvariable('conn'), 'SELECT CAST(''14:15:30 +05:30'' A
 ----
 05:45:30
 
-# TIME WITH TIME ZONE with named zone
+# TIME WITH TIME ZONE with named zone.
+# Only DST-free zones are used here: when no date is present, Firebird
+# resolves the offset against CURRENT_DATE, so zones with DST (e.g.
+# America/New_York, Europe/London) drift by +/-1 hour across the year.
 query I
-SELECT * FROM odbc_query(getvariable('conn'), 'SELECT CAST(''10:00:00 America/New_York'' AS TIME WITH TIME ZONE) FROM rdb$database')
+SELECT * FROM odbc_query(getvariable('conn'), 'SELECT CAST(''18:00:00 Asia/Tokyo'' AS TIME WITH TIME ZONE) FROM rdb$database')
 ----
-11:00:00
+06:00:00
 
 query I
-SELECT * FROM odbc_query(getvariable('conn'), 'SELECT CAST(''15:45:00 Europe/London'' AS TIME WITH TIME ZONE) FROM rdb$database')
+SELECT * FROM odbc_query(getvariable('conn'), 'SELECT CAST(''15:45:00 Asia/Kolkata'' AS TIME WITH TIME ZONE) FROM rdb$database')
 ----
-12:45:00
+07:15:00
 
 # TIME WITH TIME ZONE at UTC
 query I

--- a/test/sql/firebird/15_timestamp_with_time_zone.test
+++ b/test/sql/firebird/15_timestamp_with_time_zone.test
@@ -4,8 +4,6 @@
 
 require odbc_scanner
 
-require-env TIMEZONE_DISABLED
-
 statement ok
 SET VARIABLE conn = odbc_connect('ODBCSCANNER_DEBUG_CONN_STRING_ENV_VAR=ODBC_CONN_STRING')
 
@@ -105,12 +103,14 @@ SELECT * FROM odbc_query(getvariable('conn'),
 ----
 30
 
-# Combining DATE + TIME WITH TIME ZONE = TIMESTAMP WITH TIME ZONE
+# Combining DATE + TIME WITH TIME ZONE = TIMESTAMP WITH TIME ZONE.
+# Uses +00:00 (UTC) to avoid any chance of DST drift from CURRENT_DATE-based
+# resolution in the TIME WITH TIME ZONE operand.
 query I
-SELECT * FROM odbc_query(getvariable('conn'), 
-  'SELECT DATE ''2024-06-15'' + TIME ''14:30:00 +02:00'' FROM rdb$database')
+SELECT * FROM odbc_query(getvariable('conn'),
+  'SELECT DATE ''2024-06-15'' + TIME ''14:30:00 +00:00'' FROM rdb$database')
 ----
-2024-06-15 09:30:00
+2024-06-15 11:30:00
 
 statement ok
 CALL odbc_query(getvariable('conn'), "SET TIME ZONE 'UTC'")


### PR DESCRIPTION
Re-enables the Firebird TIME / TIMESTAMP WITH TIME ZONE tests disabled in #166 by removing the intermittent +/-1 hour drift.

## Root cause

For `TIME WITH TIME ZONE` values (no date attached), Firebird resolves named-zone offsets against `CURRENT_DATE`. Tests using `America/New_York` and `Europe/London` therefore flip between standard and daylight time as the year progresses:

- `'10:00:00 America/New_York'` → `12:00:00` in winter (EST) / `11:00:00` in summer (EDT)
- `'15:45:00 Europe/London'` → `12:45:00` in winter (GMT) / `11:45:00` in summer (BST)

This matches the history: the expected value for the NY case was flipped from `12:00:00` to `11:00:00` in 1166411 right after US DST started; a few weeks later the London case broke when UK entered BST, triggering #166.

`TIMESTAMP WITH TIME ZONE` is not affected in the same way — it carries an explicit date — but the guard was removed from its test too since that file was disabled defensively.

## Fix

- In `14_time_with_time_zone.test`, replace the two DST-sensitive named zones with DST-free ones (`Asia/Tokyo` +09:00, `Asia/Kolkata` +05:30). "Named zone support" is still covered, but results are stable year-round.
- In `15_timestamp_with_time_zone.test`, change the `DATE + TIME WITH TIME ZONE` combination operand from `+02:00` to `+00:00` for extra safety against any `CURRENT_DATE`-based resolution in the TIME operand.
- Remove `require-env TIMEZONE_DISABLED` from both files.

## Test plan

- [x] Firebird Windows (amd64) job on fdcastel/odbc-scanner@fix_firebird_tz_tests: green — run https://github.com/fdcastel/odbc-scanner/actions/runs/24903599896
- [x] Both `14_time_with_time_zone.test` and `15_timestamp_with_time_zone.test` executed (not skipped) and passed in that run