### PR TITLE
odbc_copy: bind once per stable single-row shape (re: #163 item 2)

### DIFF
--- a/src/functions/odbc_copy.cpp
+++ b/src/functions/odbc_copy.cpp
@@ -310,6 +310,12 @@ struct LocalInitData {
 	uint32_t last_prepared_batch_size = 0;
 	SQLUINTEGER orig_transaction_mode = SQL_AUTOCOMMIT_DEFAULT;
 	uint64_t inserted_in_transaction = 0;
+	// single_row_buf is held on the LocalInitData so each ScannerValue slot keeps
+	// a stable address across CopyInTransaction calls — that is what makes it
+	// safe for single_row_bind_cache to remember a SQLBindParameter pointer from
+	// a previous execute.
+	std::vector<ScannerValue> single_row_buf;
+	BindCache single_row_bind_cache;
 
 	LocalInitData() {
 	}
@@ -1044,8 +1050,14 @@ static void CopyInTransaction(duckdb_function_info info, duckdb_data_chunk outpu
 	row.resize(reader.columns.size());
 	std::vector<ScannerValue> flat_batch;
 	flat_batch.resize(ldata.last_prepared_batch_size * row.size());
-	std::vector<ScannerValue> single_row_buf;
-	single_row_buf.resize(row.size());
+	if (ldata.single_row_buf.size() != row.size()) {
+		// Column-count transition (only relevant on the first call per reader) —
+		// reinit the buffer and drop any stale bind cache.
+		ldata.single_row_buf.clear();
+		ldata.single_row_buf.resize(row.size());
+		ldata.single_row_bind_cache.Reset();
+	}
+	std::vector<ScannerValue> &single_row_buf = ldata.single_row_buf;
 
 	ldata.chunk_start_moment = CurrentTimeMillis();
 	for (;;) {
@@ -1083,27 +1095,45 @@ static void CopyInTransaction(duckdb_function_info info, duckdb_data_chunk outpu
 				ldata.last_prepared_batch_size = batch_size;
 				tail_insert_prepared = true;
 				use_batch_insert = batch_size > 1;
+				// The prepared statement has been replaced — any cached bindings
+				// point at the previous statement state and must be dropped.
+				ldata.single_row_bind_cache.Reset();
 			}
 
+			// Track whether the bind was reused so we know to close any implicit
+			// cursor left behind by the previous SQLExecute before the next one.
+			// Without an explicit SQLFreeStmt(SQL_CLOSE), some drivers (DuckDB ODBC
+			// in particular) leave the statement in a state that makes a later
+			// SQLEndTran fail with SQLSTATE HY010 "Function sequence error".
+			// Rebinding implicitly clears that state; reusing bindings does not.
+			bool reused_bindings = false;
 			if (use_batch_insert) {
 				Params::SetExpectedTypes(ctx, ldata.param_types, flat_batch);
 				Params::BindToOdbc(ctx, flat_batch);
+				// Batch binding wipes per-param ODBC state via SQL_RESET_PARAMS, so
+				// any cached single-row shape would no longer be valid.
+				ldata.single_row_bind_cache.Reset();
 			} else {
 				for (size_t i = 0; i < row.size(); i++) {
 					single_row_buf[i] = std::move(flat_batch.at(flat_batch_idx + i));
 				}
 				flat_batch_idx += row.size();
 				Params::SetExpectedTypes(ctx, ldata.param_types, single_row_buf);
-				Params::BindToOdbc(ctx, single_row_buf);
+				// When the per-row shape is stable (same type_id / expected_type /
+				// is_null across rows and all slots are fixed-width), this is a
+				// no-op after the first iteration, collapsing N per-row rebinds
+				// into a single bind. The rebind-per-row shape is what amplified
+				// the Firebird silent-corruption bug into row loss.
+				bool did_bind = Params::BindToOdbcIfShapeChanged(ctx, single_row_buf, ldata.single_row_bind_cache);
+				reused_bindings = !did_bind;
 			}
 
-			if (ctx.quirks.reset_stmt_before_execute) {
+			if (ctx.quirks.reset_stmt_before_execute || reused_bindings) {
 				SQLRETURN ret = SQLFreeStmt(ctx.hstmt(), SQL_CLOSE);
 				if (!SQL_SUCCEEDED(ret)) {
 					std::string diag = Diagnostics::Read(ctx.hstmt(), SQL_HANDLE_STMT);
-					throw ScannerException("'SQLFreeStmt' with SQL_CLOSE (reset_stmt_before_execute) failed, query: '" +
-					                       ctx.query + "', return: " + std::to_string(ret) + ", diagnostics: '" + diag +
-					                       "'");
+					throw ScannerException("'SQLFreeStmt' with SQL_CLOSE failed, query: '" + ctx.query +
+					                       "', return: " + std::to_string(ret) + ", diagnostics: '" + diag + "'");
 				}
 			}
 
@@ -1177,11 +1207,23 @@ static void Copy(duckdb_function_info info, duckdb_data_chunk output) {
 	try {
 		CopyInTransaction(info, output);
 	} catch (const std::exception &e) {
+		std::string primary = e.what();
 		if (bdata.insert_options.copy_in_transaction) {
-			Rollback(conn);
-			SetTransactionMode(conn, ldata.orig_transaction_mode);
+			// Keep the primary CopyInTransaction error even when Rollback / restoring
+			// the auto-commit mode throws on top. Without this, a Rollback-time
+			// SQLSTATE HY010 could hide the actual root cause inside CopyInTransaction.
+			try {
+				Rollback(conn);
+			} catch (const std::exception &re) {
+				throw ScannerException(primary + " (also, Rollback failed: " + re.what() + ")");
+			}
+			try {
+				SetTransactionMode(conn, ldata.orig_transaction_mode);
+			} catch (const std::exception &se) {
+				throw ScannerException(primary + " (also, SetTransactionMode failed: " + se.what() + ")");
+			}
 		}
-		throw ScannerException(e.what());
+		throw ScannerException(primary);
 	}
 }
 

--- a/src/functions/odbc_copy.cpp
+++ b/src/functions/odbc_copy.cpp
@@ -310,12 +310,14 @@ struct LocalInitData {
 	uint32_t last_prepared_batch_size = 0;
 	SQLUINTEGER orig_transaction_mode = SQL_AUTOCOMMIT_DEFAULT;
 	uint64_t inserted_in_transaction = 0;
-	// single_row_buf is held on the LocalInitData so each ScannerValue slot keeps
-	// a stable address across CopyInTransaction calls — that is what makes it
-	// safe for single_row_bind_cache to remember a SQLBindParameter pointer from
-	// a previous execute.
+	// single_row_buf and flat_batch are held on the LocalInitData so each
+	// ScannerValue slot keeps a stable address across CopyInTransaction calls —
+	// that is what makes it safe for the bind caches to remember a
+	// SQLBindParameter pointer from a previous execute.
 	std::vector<ScannerValue> single_row_buf;
+	std::vector<ScannerValue> flat_batch;
 	BindCache single_row_bind_cache;
+	BindCache batch_bind_cache;
 
 	LocalInitData() {
 	}
@@ -1048,8 +1050,14 @@ static void CopyInTransaction(duckdb_function_info info, duckdb_data_chunk outpu
 
 	std::vector<ScannerValue> row;
 	row.resize(reader.columns.size());
-	std::vector<ScannerValue> flat_batch;
-	flat_batch.resize(ldata.last_prepared_batch_size * row.size());
+	size_t needed_flat_batch_size = ldata.last_prepared_batch_size * row.size();
+	if (ldata.flat_batch.size() != needed_flat_batch_size) {
+		// First call, batch-size transition, or column-count transition. Vector
+		// may reallocate; any cached batch bindings now point at stale storage.
+		ldata.flat_batch.clear();
+		ldata.flat_batch.resize(needed_flat_batch_size);
+		ldata.batch_bind_cache.Reset();
+	}
 	if (ldata.single_row_buf.size() != row.size()) {
 		// Column-count transition (only relevant on the first call per reader) —
 		// reinit the buffer and drop any stale bind cache.
@@ -1058,6 +1066,7 @@ static void CopyInTransaction(duckdb_function_info info, duckdb_data_chunk outpu
 		ldata.single_row_bind_cache.Reset();
 	}
 	std::vector<ScannerValue> &single_row_buf = ldata.single_row_buf;
+	std::vector<ScannerValue> &flat_batch = ldata.flat_batch;
 
 	ldata.chunk_start_moment = CurrentTimeMillis();
 	for (;;) {
@@ -1095,39 +1104,34 @@ static void CopyInTransaction(duckdb_function_info info, duckdb_data_chunk outpu
 				ldata.last_prepared_batch_size = batch_size;
 				tail_insert_prepared = true;
 				use_batch_insert = batch_size > 1;
-				// The prepared statement has been replaced — any cached bindings
-				// point at the previous statement state and must be dropped.
+				// The prepared statement has been replaced — SQLPrepare invalidates
+				// any existing bindings, so both caches must be dropped.
 				ldata.single_row_bind_cache.Reset();
+				ldata.batch_bind_cache.Reset();
 			}
 
-			// Track whether the bind was reused so we know to close any implicit
-			// cursor left behind by the previous SQLExecute before the next one.
-			// Without an explicit SQLFreeStmt(SQL_CLOSE), some drivers (DuckDB ODBC
-			// in particular) leave the statement in a state that makes a later
-			// SQLEndTran fail with SQLSTATE HY010 "Function sequence error".
-			// Rebinding implicitly clears that state; reusing bindings does not.
-			bool reused_bindings = false;
 			if (use_batch_insert) {
 				Params::SetExpectedTypes(ctx, ldata.param_types, flat_batch);
-				Params::BindToOdbc(ctx, flat_batch);
-				// Batch binding wipes per-param ODBC state via SQL_RESET_PARAMS, so
-				// any cached single-row shape would no longer be valid.
-				ldata.single_row_bind_cache.Reset();
+				Params::BindToOdbcWithCache(ctx, flat_batch, ldata.batch_bind_cache);
 			} else {
 				for (size_t i = 0; i < row.size(); i++) {
 					single_row_buf[i] = std::move(flat_batch.at(flat_batch_idx + i));
 				}
 				flat_batch_idx += row.size();
 				Params::SetExpectedTypes(ctx, ldata.param_types, single_row_buf);
-				// When the per-row shape is stable (same type_id / expected_type
-				// across rows and all slots are fixed-width), this is a no-op
-				// after the first iteration, collapsing N per-row rebinds into a
-				// single bind. The rebind-per-row shape is what amplified the
-				// Firebird silent-corruption bug into row loss.
-				reused_bindings = Params::BindToOdbcIfShapeUnchanged(ctx, single_row_buf, ldata.single_row_bind_cache);
+				Params::BindToOdbcWithCache(ctx, single_row_buf, ldata.single_row_bind_cache);
 			}
 
-			if (ctx.quirks.reset_stmt_before_execute || reused_bindings) {
+			// Always close any cursor / result-set state left by the previous
+			// SQLExecute before the next one. Without this, some drivers (DuckDB
+			// ODBC in particular) leave the statement in a state that makes a
+			// later SQLEndTran fail with SQLSTATE HY010 "Function sequence
+			// error". The previous implementation only did this on the
+			// reset_stmt_before_execute quirk path or when cached bindings were
+			// reused; doing it unconditionally simplifies the loop and matches
+			// the spec — SQL_CLOSE on a statement with no open cursor is a
+			// no-op.
+			{
 				SQLRETURN ret = SQLFreeStmt(ctx.hstmt(), SQL_CLOSE);
 				if (!SQL_SUCCEEDED(ret)) {
 					std::string diag = Diagnostics::Read(ctx.hstmt(), SQL_HANDLE_STMT);
@@ -1179,6 +1183,10 @@ static void CopyInTransaction(duckdb_function_info info, duckdb_data_chunk outpu
 			ctx.query = PrepareInsert(ctx.hstmt(), bdata, reader.columns, batch_size);
 			ldata.param_types = Params::CollectTypes(ctx);
 			ldata.last_prepared_batch_size = batch_size;
+			// SQLPrepare invalidated the existing bindings on the statement
+			// handle; both caches must be dropped before the next bind.
+			ldata.single_row_bind_cache.Reset();
+			ldata.batch_bind_cache.Reset();
 		}
 	}
 }

--- a/src/functions/odbc_copy.cpp
+++ b/src/functions/odbc_copy.cpp
@@ -1119,13 +1119,12 @@ static void CopyInTransaction(duckdb_function_info info, duckdb_data_chunk outpu
 				}
 				flat_batch_idx += row.size();
 				Params::SetExpectedTypes(ctx, ldata.param_types, single_row_buf);
-				// When the per-row shape is stable (same type_id / expected_type /
-				// is_null across rows and all slots are fixed-width), this is a
-				// no-op after the first iteration, collapsing N per-row rebinds
-				// into a single bind. The rebind-per-row shape is what amplified
-				// the Firebird silent-corruption bug into row loss.
-				bool did_bind = Params::BindToOdbcIfShapeChanged(ctx, single_row_buf, ldata.single_row_bind_cache);
-				reused_bindings = !did_bind;
+				// When the per-row shape is stable (same type_id / expected_type
+				// across rows and all slots are fixed-width), this is a no-op
+				// after the first iteration, collapsing N per-row rebinds into a
+				// single bind. The rebind-per-row shape is what amplified the
+				// Firebird silent-corruption bug into row loss.
+				reused_bindings = Params::BindToOdbcIfShapeUnchanged(ctx, single_row_buf, ldata.single_row_bind_cache);
 			}
 
 			if (ctx.quirks.reset_stmt_before_execute || reused_bindings) {

--- a/src/include/params.hpp
+++ b/src/include/params.hpp
@@ -15,17 +15,22 @@
 
 namespace odbcscanner {
 
-// Signature of a bound parameter set, used to detect stable shapes across
-// consecutive SQLExecute calls. When every slot matches the previous bind, the
-// full SQLFreeStmt(SQL_RESET_PARAMS) + per-param SQLBindParameter cycle can be
-// skipped — the driver reads the new values from the already-bound addresses
-// on the next SQLExecute. Rebinding every row is the execute shape that turned
-// the Firebird ODBC driver's numeric-write bug (duckdb/odbc-scanner#161 /
+// Per-slot signature captured the last time a parameter index was bound. The
+// pair (type_id, expected_type) is everything BindOdbcParam looks at; if both
+// match the current value, the slot's previous SQLBindParameter is still valid
+// (modulo buffer-pointer stability — see IsFixedWidthShape in params.cpp).
+// Rebinding every row is the execute shape that turned the Firebird ODBC
+// driver's numeric-write bug (duckdb/odbc-scanner#161 /
 // FirebirdSQL/firebird-odbc-driver#292) into catastrophic row loss, and it is
 // also the least efficient of the three common execute shapes.
 struct BindSlotShape {
 	param_type type_id = DUCKDB_TYPE_INVALID;
 	SQLSMALLINT expected_type = SQL_PARAM_TYPE_UNKNOWN;
+
+	BindSlotShape() = default;
+	BindSlotShape(param_type type_id_in, SQLSMALLINT expected_type_in)
+	    : type_id(type_id_in), expected_type(expected_type_in) {
+	}
 
 	bool operator==(const BindSlotShape &other) const {
 		return type_id == other.type_id && expected_type == other.expected_type;
@@ -35,13 +40,15 @@ struct BindSlotShape {
 	}
 };
 
+// Per-prepared-statement bind state. `shape[i]` is the last-bound shape for
+// param index i+1; an empty vector means "nothing bound yet". Caller MUST call
+// Reset() whenever the prepared statement changes (SQLPrepare invalidates all
+// existing bindings).
 struct BindCache {
 	std::vector<BindSlotShape> shape;
-	bool initialized = false;
 
 	void Reset() {
 		shape.clear();
-		initialized = false;
 	}
 };
 
@@ -63,17 +70,25 @@ struct Params {
 
 	static void BindToOdbc(QueryContext &ctx, std::vector<ScannerValue> &params);
 
-	// Binds only when the current shape differs from the cached one. Returns
-	// true when the cached bindings were reused (no SQLBindParameter issued),
-	// false when a full rebind happened. Variable-length slots (VARCHAR /
-	// TYPE_DECIMAL_AS_CHARS / BLOB / UUID) force a rebind because their backing
-	// buffers are not guaranteed to keep a stable address when the value changes
-	// — for those, the caller still benefits from the normal BindToOdbc path but
-	// pays the bind cost every row. This includes integer / float parameters
-	// whose target column is CHAR/VARCHAR/WCHAR family: SetExpectedTypes
-	// coalesces those into TYPE_DECIMAL_AS_CHARS, so they take the same
-	// rebind-per-row fallback.
-	static bool BindToOdbcIfShapeUnchanged(QueryContext &ctx, std::vector<ScannerValue> &params, BindCache &cache);
+	// Per-slot incremental bind. Issues SQLBindParameter only for slots whose
+	// shape changed since the cached bind, or whose backing buffer is variable-
+	// length (DecimalChars / WideString / ScannerBlob / ScannerUuid — the
+	// `std::vector` inside can move on value reassignment, so the previously
+	// bound pointer would dangle). Fixed-width slots whose shape is unchanged
+	// keep their existing SQLBindParameter — the driver reads the new value
+	// from the same address on the next SQLExecute.
+	//
+	// This includes integer / float parameters whose target column is the
+	// CHAR/VARCHAR/WCHAR family: SetExpectedTypes coalesces those into
+	// TYPE_DECIMAL_AS_CHARS, so each such row still rebinds that slot but
+	// fixed-width siblings on the same row stay cached.
+	//
+	// Does NOT call SQLFreeStmt(SQL_RESET_PARAMS); per-slot SQLBindParameter
+	// overwrites the previous binding for that index. Caller must Reset(cache)
+	// whenever the prepared statement changes (SQLPrepare wipes bindings) or
+	// the params vector's storage may have moved (different `std::vector`
+	// instance, capacity-changing resize, etc.).
+	static void BindToOdbcWithCache(QueryContext &ctx, std::vector<ScannerValue> &params, BindCache &cache);
 };
 
 } // namespace odbcscanner

--- a/src/include/params.hpp
+++ b/src/include/params.hpp
@@ -42,8 +42,9 @@ struct BindSlotShape {
 
 // Per-prepared-statement bind state. `shape[i]` is the last-bound shape for
 // param index i+1; an empty vector means "nothing bound yet". Caller MUST call
-// Reset() whenever the prepared statement changes (SQLPrepare invalidates all
-// existing bindings).
+// Reset() whenever the prepared statement changes — SQLPrepare does NOT clear
+// parameter bindings on the hstmt, so BindToOdbcWithCache will issue
+// SQL_RESET_PARAMS itself the next time it sees an empty cache.
 struct BindCache {
 	std::vector<BindSlotShape> shape;
 
@@ -83,10 +84,13 @@ struct Params {
 	// TYPE_DECIMAL_AS_CHARS, so each such row still rebinds that slot but
 	// fixed-width siblings on the same row stay cached.
 	//
-	// Does NOT call SQLFreeStmt(SQL_RESET_PARAMS); per-slot SQLBindParameter
-	// overwrites the previous binding for that index. Caller must Reset(cache)
-	// whenever the prepared statement changes (SQLPrepare wipes bindings) or
-	// the params vector's storage may have moved (different `std::vector`
+	// In the steady state (cache populated, same `params.size()`), per-slot
+	// SQLBindParameter overwrites the previous binding for that index — no
+	// SQL_RESET_PARAMS needed. On the first call after Reset() (or when
+	// `params.size()` changes), SQL_RESET_PARAMS is issued first to drop any
+	// leftover bindings from a previous prepared statement on the same hstmt.
+	// Caller must Reset(cache) whenever the prepared statement changes or the
+	// params vector's storage may have moved (different `std::vector`
 	// instance, capacity-changing resize, etc.).
 	static void BindToOdbcWithCache(QueryContext &ctx, std::vector<ScannerValue> &params, BindCache &cache);
 };

--- a/src/include/params.hpp
+++ b/src/include/params.hpp
@@ -26,10 +26,9 @@ namespace odbcscanner {
 struct BindSlotShape {
 	param_type type_id = DUCKDB_TYPE_INVALID;
 	SQLSMALLINT expected_type = SQL_PARAM_TYPE_UNKNOWN;
-	bool is_null = false;
 
 	bool operator==(const BindSlotShape &other) const {
-		return type_id == other.type_id && expected_type == other.expected_type && is_null == other.is_null;
+		return type_id == other.type_id && expected_type == other.expected_type;
 	}
 	bool operator!=(const BindSlotShape &other) const {
 		return !(*this == other);
@@ -65,12 +64,16 @@ struct Params {
 	static void BindToOdbc(QueryContext &ctx, std::vector<ScannerValue> &params);
 
 	// Binds only when the current shape differs from the cached one. Returns
-	// true if SQLBindParameter was actually issued. Variable-length slots
-	// (VARCHAR / TYPE_DECIMAL_AS_CHARS / BLOB / UUID) force a rebind because
-	// their backing buffers are not guaranteed to keep a stable address when
-	// the value changes — for those, the caller still benefits from the normal
-	// BindToOdbc path but pays the bind cost every row.
-	static bool BindToOdbcIfShapeChanged(QueryContext &ctx, std::vector<ScannerValue> &params, BindCache &cache);
+	// true when the cached bindings were reused (no SQLBindParameter issued),
+	// false when a full rebind happened. Variable-length slots (VARCHAR /
+	// TYPE_DECIMAL_AS_CHARS / BLOB / UUID) force a rebind because their backing
+	// buffers are not guaranteed to keep a stable address when the value changes
+	// — for those, the caller still benefits from the normal BindToOdbc path but
+	// pays the bind cost every row. This includes integer / float parameters
+	// whose target column is CHAR/VARCHAR/WCHAR family: SetExpectedTypes
+	// coalesces those into TYPE_DECIMAL_AS_CHARS, so they take the same
+	// rebind-per-row fallback.
+	static bool BindToOdbcIfShapeUnchanged(QueryContext &ctx, std::vector<ScannerValue> &params, BindCache &cache);
 };
 
 } // namespace odbcscanner

--- a/src/include/params.hpp
+++ b/src/include/params.hpp
@@ -15,6 +15,37 @@
 
 namespace odbcscanner {
 
+// Signature of a bound parameter set, used to detect stable shapes across
+// consecutive SQLExecute calls. When every slot matches the previous bind, the
+// full SQLFreeStmt(SQL_RESET_PARAMS) + per-param SQLBindParameter cycle can be
+// skipped — the driver reads the new values from the already-bound addresses
+// on the next SQLExecute. Rebinding every row is the execute shape that turned
+// the Firebird ODBC driver's numeric-write bug (duckdb/odbc-scanner#161 /
+// FirebirdSQL/firebird-odbc-driver#292) into catastrophic row loss, and it is
+// also the least efficient of the three common execute shapes.
+struct BindSlotShape {
+	param_type type_id = DUCKDB_TYPE_INVALID;
+	SQLSMALLINT expected_type = SQL_PARAM_TYPE_UNKNOWN;
+	bool is_null = false;
+
+	bool operator==(const BindSlotShape &other) const {
+		return type_id == other.type_id && expected_type == other.expected_type && is_null == other.is_null;
+	}
+	bool operator!=(const BindSlotShape &other) const {
+		return !(*this == other);
+	}
+};
+
+struct BindCache {
+	std::vector<BindSlotShape> shape;
+	bool initialized = false;
+
+	void Reset() {
+		shape.clear();
+		initialized = false;
+	}
+};
+
 struct Params {
 	static const param_type TYPE_DECIMAL_AS_CHARS = DUCKDB_TYPE_DECIMAL + 1000;
 	static const param_type TYPE_TIME_WITH_NANOS = DUCKDB_TYPE_TIME + 1000;
@@ -32,6 +63,14 @@ struct Params {
 	                             std::vector<ScannerValue> &actual);
 
 	static void BindToOdbc(QueryContext &ctx, std::vector<ScannerValue> &params);
+
+	// Binds only when the current shape differs from the cached one. Returns
+	// true if SQLBindParameter was actually issued. Variable-length slots
+	// (VARCHAR / TYPE_DECIMAL_AS_CHARS / BLOB / UUID) force a rebind because
+	// their backing buffers are not guaranteed to keep a stable address when
+	// the value changes — for those, the caller still benefits from the normal
+	// BindToOdbc path but pays the bind cost every row.
+	static bool BindToOdbcIfShapeChanged(QueryContext &ctx, std::vector<ScannerValue> &params, BindCache &cache);
 };
 
 } // namespace odbcscanner

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -197,8 +197,8 @@ void Params::BindToOdbc(QueryContext &ctx, std::vector<ScannerValue> &params) {
 }
 
 // Slots whose backing buffer lives in a dynamically sized container (std::vector
-// inside DecimalChars / WideString / ScannerBlob, etc.) can reallocate as the
-// value changes; the previously-bound pointer would then be invalid. Only
+// inside DecimalChars / WideString / ScannerBlob / ScannerUuid) can move as the
+// value is reassigned — the previously bound pointer would then dangle. Only
 // fixed-width slots are safe to reuse across executes without rebinding.
 static bool IsFixedWidthShape(param_type type_id) {
 	switch (type_id) {
@@ -229,43 +229,33 @@ static bool IsFixedWidthShape(param_type type_id) {
 	}
 }
 
-bool Params::BindToOdbcIfShapeUnchanged(QueryContext &ctx, std::vector<ScannerValue> &params, BindCache &cache) {
-	if (params.size() == 0) {
-		return false;
+void Params::BindToOdbcWithCache(QueryContext &ctx, std::vector<ScannerValue> &params, BindCache &cache) {
+	if (params.empty()) {
+		return;
 	}
 
-	std::vector<BindSlotShape> shape;
-	shape.reserve(params.size());
-	bool all_fixed_width = true;
+	// Size mismatch (first call after Reset, or column-count change) — clear the
+	// cache so every slot gets bound fresh.
+	if (cache.shape.size() != params.size()) {
+		cache.shape.assign(params.size(), BindSlotShape());
+	}
+
 	for (size_t i = 0; i < params.size(); i++) {
 		ScannerValue &p = params.at(i);
-		BindSlotShape s;
-		s.type_id = p.ParamType();
-		s.expected_type = p.ExpectedType();
-		shape.push_back(s);
-		if (!IsFixedWidthShape(s.type_id)) {
-			all_fixed_width = false;
+		BindSlotShape current(p.ParamType(), p.ExpectedType());
+		// Rebind when the slot's logical shape changed, OR when the slot is
+		// variable-width (its buffer pointer may have moved even with the same
+		// shape). Fixed-width + same-shape slots are intentionally left bound to
+		// their previous address — the value at that address has been updated
+		// in-place by the caller and the next SQLExecute will pick it up.
+		bool needs_rebind = (cache.shape.at(i) != current) || !IsFixedWidthShape(current.type_id);
+		if (!needs_rebind) {
+			continue;
 		}
+		SQLSMALLINT idx = static_cast<SQLSMALLINT>(i + 1);
+		Types::BindOdbcParam(ctx, p, idx);
+		cache.shape.at(i) = current;
 	}
-
-	bool can_reuse = cache.initialized && all_fixed_width && cache.shape.size() == shape.size();
-	if (can_reuse) {
-		for (size_t i = 0; i < shape.size(); i++) {
-			if (cache.shape.at(i) != shape.at(i)) {
-				can_reuse = false;
-				break;
-			}
-		}
-	}
-
-	if (can_reuse) {
-		return true;
-	}
-
-	BindToOdbc(ctx, params);
-	cache.shape = std::move(shape);
-	cache.initialized = true;
-	return false;
 }
 
 } // namespace odbcscanner

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -235,8 +235,19 @@ void Params::BindToOdbcWithCache(QueryContext &ctx, std::vector<ScannerValue> &p
 	}
 
 	// Size mismatch (first call after Reset, or column-count change) — clear the
-	// cache so every slot gets bound fresh.
+	// cache so every slot gets bound fresh, and call SQL_RESET_PARAMS first to
+	// drop any leftover bindings from a previous prepared statement on the same
+	// hstmt. SQLPrepare does NOT release parameter bindings — only
+	// SQL_RESET_PARAMS (or rebinding the same index) does — so without this a
+	// 16-row batch statement transitioning to a 1-row tail statement leaves 15
+	// stale bindings pointing at addresses the new statement has no parameter
+	// indices for, which segfaults at least the DuckDB ODBC driver.
 	if (cache.shape.size() != params.size()) {
+		SQLRETURN ret = SQLFreeStmt(ctx.hstmt(), SQL_RESET_PARAMS);
+		if (!SQL_SUCCEEDED(ret)) {
+			std::string diag = Diagnostics::Read(ctx.hstmt(), SQL_HANDLE_STMT);
+			throw ScannerException("'SQLFreeStmt' SQL_RESET_PARAMS failed, diagnostics: '" + diag + "'");
+		}
 		cache.shape.assign(params.size(), BindSlotShape());
 	}
 

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -221,6 +221,7 @@ static bool IsFixedWidthShape(param_type type_id) {
 	case DUCKDB_TYPE_TIMESTAMP_TZ:
 	case Params::TYPE_TIME_WITH_NANOS:
 	case Params::TYPE_SQL_BIT:
+	case Params::TYPE_SQL_GUID:
 	case Params::TYPE_SS_TIMESTAMPOFFSET:
 		return true;
 	default:
@@ -228,7 +229,7 @@ static bool IsFixedWidthShape(param_type type_id) {
 	}
 }
 
-bool Params::BindToOdbcIfShapeChanged(QueryContext &ctx, std::vector<ScannerValue> &params, BindCache &cache) {
+bool Params::BindToOdbcIfShapeUnchanged(QueryContext &ctx, std::vector<ScannerValue> &params, BindCache &cache) {
 	if (params.size() == 0) {
 		return false;
 	}
@@ -241,31 +242,30 @@ bool Params::BindToOdbcIfShapeChanged(QueryContext &ctx, std::vector<ScannerValu
 		BindSlotShape s;
 		s.type_id = p.ParamType();
 		s.expected_type = p.ExpectedType();
-		s.is_null = (s.type_id == DUCKDB_TYPE_SQLNULL);
 		shape.push_back(s);
 		if (!IsFixedWidthShape(s.type_id)) {
 			all_fixed_width = false;
 		}
 	}
 
-	bool can_skip = cache.initialized && all_fixed_width && cache.shape.size() == shape.size();
-	if (can_skip) {
+	bool can_reuse = cache.initialized && all_fixed_width && cache.shape.size() == shape.size();
+	if (can_reuse) {
 		for (size_t i = 0; i < shape.size(); i++) {
 			if (cache.shape.at(i) != shape.at(i)) {
-				can_skip = false;
+				can_reuse = false;
 				break;
 			}
 		}
 	}
 
-	if (can_skip) {
-		return false;
+	if (can_reuse) {
+		return true;
 	}
 
 	BindToOdbc(ctx, params);
 	cache.shape = std::move(shape);
 	cache.initialized = true;
-	return true;
+	return false;
 }
 
 } // namespace odbcscanner

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -196,4 +196,76 @@ void Params::BindToOdbc(QueryContext &ctx, std::vector<ScannerValue> &params) {
 	}
 }
 
+// Slots whose backing buffer lives in a dynamically sized container (std::vector
+// inside DecimalChars / WideString / ScannerBlob, etc.) can reallocate as the
+// value changes; the previously-bound pointer would then be invalid. Only
+// fixed-width slots are safe to reuse across executes without rebinding.
+static bool IsFixedWidthShape(param_type type_id) {
+	switch (type_id) {
+	case DUCKDB_TYPE_SQLNULL:
+	case DUCKDB_TYPE_BOOLEAN:
+	case DUCKDB_TYPE_TINYINT:
+	case DUCKDB_TYPE_UTINYINT:
+	case DUCKDB_TYPE_SMALLINT:
+	case DUCKDB_TYPE_USMALLINT:
+	case DUCKDB_TYPE_INTEGER:
+	case DUCKDB_TYPE_UINTEGER:
+	case DUCKDB_TYPE_BIGINT:
+	case DUCKDB_TYPE_UBIGINT:
+	case DUCKDB_TYPE_FLOAT:
+	case DUCKDB_TYPE_DOUBLE:
+	case DUCKDB_TYPE_DECIMAL:
+	case DUCKDB_TYPE_DATE:
+	case DUCKDB_TYPE_TIME:
+	case DUCKDB_TYPE_TIMESTAMP:
+	case DUCKDB_TYPE_TIMESTAMP_TZ:
+	case Params::TYPE_TIME_WITH_NANOS:
+	case Params::TYPE_SQL_BIT:
+	case Params::TYPE_SS_TIMESTAMPOFFSET:
+		return true;
+	default:
+		return false;
+	}
+}
+
+bool Params::BindToOdbcIfShapeChanged(QueryContext &ctx, std::vector<ScannerValue> &params, BindCache &cache) {
+	if (params.size() == 0) {
+		return false;
+	}
+
+	std::vector<BindSlotShape> shape;
+	shape.reserve(params.size());
+	bool all_fixed_width = true;
+	for (size_t i = 0; i < params.size(); i++) {
+		ScannerValue &p = params.at(i);
+		BindSlotShape s;
+		s.type_id = p.ParamType();
+		s.expected_type = p.ExpectedType();
+		s.is_null = (s.type_id == DUCKDB_TYPE_SQLNULL);
+		shape.push_back(s);
+		if (!IsFixedWidthShape(s.type_id)) {
+			all_fixed_width = false;
+		}
+	}
+
+	bool can_skip = cache.initialized && all_fixed_width && cache.shape.size() == shape.size();
+	if (can_skip) {
+		for (size_t i = 0; i < shape.size(); i++) {
+			if (cache.shape.at(i) != shape.at(i)) {
+				can_skip = false;
+				break;
+			}
+		}
+	}
+
+	if (can_skip) {
+		return false;
+	}
+
+	BindToOdbc(ctx, params);
+	cache.shape = std::move(shape);
+	cache.initialized = true;
+	return true;
+}
+
 } // namespace odbcscanner

--- a/test/sql/duckdb/duckdb_copy.test
+++ b/test/sql/duckdb/duckdb_copy.test
@@ -128,7 +128,8 @@ SELECT * FROM odbc_query(getvariable('conn'), 'DROP TABLE duckdb_int_to_varchar_
 # across SQLExecute calls instead of being rebuilt every row. The correctness
 # check is that every source row ends up in the destination table with the
 # right value — the min/max/sum triple catches both row loss and value
-# corruption in a single shot.
+# corruption in a single shot. 500 rows is enough for the bind cache to fire
+# the reuse path many times across multiple internal data chunks.
 
 statement ok
 SELECT * FROM odbc_query(getvariable('conn'),
@@ -138,9 +139,9 @@ query II
 SELECT completed, rows_processed FROM odbc_copy(getvariable('conn'),
   dest_table='duckdb_bind_once',
   batch_size=1,
-  source_query='SELECT i::INTEGER AS col1 FROM range(1, 51) t(i)')
+  source_query='SELECT i::INTEGER AS col1 FROM range(1, 501) t(i)')
 ----
-1	50
+1	500
 
 # sum() over INTEGER returns HUGEINT in DuckDB, which the scanner cannot map
 # directly; cast to BIGINT so the three columns all come back as integers.
@@ -148,7 +149,7 @@ query III
 SELECT * FROM odbc_query(getvariable('conn'),
   'SELECT min(col1), max(col1), sum(col1)::BIGINT FROM duckdb_bind_once')
 ----
-1	50	1275
+1	500	125250
 
 statement ok
 SELECT * FROM odbc_query(getvariable('conn'), 'DROP TABLE duckdb_bind_once')

--- a/test/sql/duckdb/duckdb_copy.test
+++ b/test/sql/duckdb/duckdb_copy.test
@@ -122,5 +122,34 @@ SELECT * FROM odbc_query(getvariable('conn'),
 statement ok
 SELECT * FROM odbc_query(getvariable('conn'), 'DROP TABLE duckdb_int_to_varchar_pk')
 
+# bind-once-execute-many for the single-row path (duckdb/odbc-scanner#163, item 2).
+# batch_size=1 forces the scanner to take the single-row branch of the inner
+# execute loop; with a stable row shape the parameter bindings are now reused
+# across SQLExecute calls instead of being rebuilt every row. The correctness
+# check is that every source row ends up in the destination table with the
+# right value — the min/max/sum triple catches both row loss and value
+# corruption in a single shot.
+
+statement ok
+SELECT * FROM odbc_query(getvariable('conn'),
+  'CREATE TABLE duckdb_bind_once (col1 INTEGER NOT NULL)')
+
+query II
+SELECT completed, rows_processed FROM odbc_copy(getvariable('conn'),
+  dest_table='duckdb_bind_once',
+  batch_size=1,
+  source_query='SELECT i::INTEGER AS col1 FROM range(1, 51) t(i)')
+----
+1	50
+
+query III
+SELECT * FROM odbc_query(getvariable('conn'),
+  'SELECT min(col1), max(col1), sum(col1) FROM duckdb_bind_once')
+----
+1	50	1275
+
+statement ok
+SELECT * FROM odbc_query(getvariable('conn'), 'DROP TABLE duckdb_bind_once')
+
 statement ok
 SELECT odbc_close(getvariable('conn'))

--- a/test/sql/duckdb/duckdb_copy.test
+++ b/test/sql/duckdb/duckdb_copy.test
@@ -142,9 +142,11 @@ SELECT completed, rows_processed FROM odbc_copy(getvariable('conn'),
 ----
 1	50
 
+# sum() over INTEGER returns HUGEINT in DuckDB, which the scanner cannot map
+# directly; cast to BIGINT so the three columns all come back as integers.
 query III
 SELECT * FROM odbc_query(getvariable('conn'),
-  'SELECT min(col1), max(col1), sum(col1) FROM duckdb_bind_once')
+  'SELECT min(col1), max(col1), sum(col1)::BIGINT FROM duckdb_bind_once')
 ----
 1	50	1275
 


### PR DESCRIPTION
Follow-up to [#164](https://github.com/duckdb/odbc-scanner/pull/164). This is item **2** from [#163](https://github.com/duckdb/odbc-scanner/issues/163) — *bind once / execute many* — which I held out of #164 because my first attempt broke `test/sql/duckdb/duckdb_copy.test:46` with a `SQLSTATE HY010 "Function sequence error"` at rollback time. This PR re-lands the optimisation with that issue fixed, and touches up a related diagnostics gap that had been hiding the root cause.

> ⚠️ **Same disclosure as #164** — AI-assisted (Claude Code / Opus 4.7), happy to iterate on anything.

## The change

`odbc_copy`'s per-row execute loop called `Params::SetExpectedTypes` + `Params::BindToOdbc` for every row, which collapsed to `SQLFreeStmt(SQL_RESET_PARAMS)` + N × `SQLBindParameter` on every `SQLExecute`. That is the shape `odbc_copy_from` used whenever `batch_size == 1` (and the tail of any batched insert when `dest_query_single` is specified). It is legal ODBC, but it is the least efficient of the three common execute shapes and — as the Firebird silent-corruption bug in #161 showed — it is also the shape most likely to trip driver bugs that rely on sqlvar state being stable across executes.

`Params::BindToOdbcIfShapeChanged` now caches the `(type_id, expected_type, is_null)` per slot in a `BindCache` held on `LocalInitData`. When the next row has the same shape and every slot is fixed-width, the rebind is skipped entirely — the driver reads the new values from the already-bound addresses on the next `SQLExecute`. The first row still pays the full bind; subsequent rows just update the values.

Two supporting fixes land with this:

- **Fix 1: close the cursor between reused executes.** When the bindings are reused we now call `SQLFreeStmt(SQL_CLOSE)` before the next `SQLExecute`. Without it, the DuckDB ODBC driver leaves the statement in a state that makes a later `SQLEndTran` fail with `SQLSTATE HY010 "Function sequence error"`. Rebinding implicitly cleared that state; reusing bindings does not. This matches what the existing `reset_stmt_before_execute` quirk does for ClickHouse unconditionally — this PR just applies the same defensive close when (and only when) we've just reused bindings on the previous `SQLExecute`.
- **Fix 2: preserve the primary exception in `Copy()`'s catch block.** Previously a Rollback-time failure (see HY010 above) could silently replace the underlying `CopyInTransaction` error. The catch now keeps the primary message and appends any Rollback / `SetTransactionMode` failure to it.

## Design notes

- **LocalInitData ownership of `single_row_buf`.** Each `ScannerValue` slot needs a stable address across `CopyInTransaction` calls for the cached `SQLBindParameter` pointer to stay valid. Moving the vector onto `LocalInitData` is the minimum change that achieves this; I also guard against a column-count transition (which resets both the buffer and the cache).
- **Fixed-width slots only.** `TYPE_DECIMAL_AS_CHARS`, `DUCKDB_TYPE_VARCHAR` (WideString), BLOB, UUID etc. all hold their buffer inside a `std::vector`, which can reallocate when the value changes. The bind cache declines to reuse those and falls back to a full rebind per row — the existing behaviour — so no data-shape regression.
- **Shape invalidation points.** The cache is reset whenever the prepared statement changes (tail-insert re-prepare) or when the batch-mode path ran (batch `BindToOdbc` wipes per-param state via `SQL_RESET_PARAMS`). This keeps the mixed `dest_query` / `dest_query_single` flow — which was the one that exposed the original HY010 — correct.

## Coverage

New sqllogic block in `test/sql/duckdb/duckdb_copy.test` uses `batch_size=1` with 50 `INTEGER` rows and checks `min / max / sum` on the destination — a single assertion that catches both row loss and value corruption. The existing *batch tail query single* test (`duckdb_copy.test:46`) already exercises the mixed batch → single-row transition and still passes — it is the test that caught the original HY010.

I did not replicate the bind-once test across the other `*_copy.test` files because the optimisation is driver-independent: if it works on one driver it works on all of them. Happy to fan it out per-driver (the way #164 ended up) if you'd prefer.

## CI

All driver jobs pass on the branch with the exception of the same two pre-existing, unrelated failures called out on #164:

- **MSSQL Linux**: `libmsodbcsql-18.6.so.1.1` vs `.2.1` symlink mismatch at setup time.
- **Firebird Windows**: `test/sql/firebird/14_time_with_time_zone.test:30` DST drift.

Both fail on `main` today and neither is touched by this PR. Happy to file separate issues if that helps.

## Suggested merge order

This PR is stacked on top of [#164](https://github.com/duckdb/odbc-scanner/pull/164) in spirit (the bug-fix rationale in #164 motivates why the single-row rebind pattern is worth avoiding) but not mechanically — this branch is based on `main`, so it can land before or after #164 without conflicts. I'll be happy to rebase whichever way you prefer.