### PR TITLE
Fix handling for BLOB and UUID parameters

### DIFF
--- a/src/scanner_value.cpp
+++ b/src/scanner_value.cpp
@@ -368,7 +368,7 @@ void ScannerValue::AssignByType(param_type type_id, InternalValue &val, ScannerV
 		val.blob = std::move(other.Value<ScannerBlob>());
 		break;
 	case DUCKDB_TYPE_UUID:
-		new (&val.blob) ScannerUuid;
+		new (&val.uuid) ScannerUuid;
 		val.uuid = std::move(other.Value<ScannerUuid>());
 		break;
 	case DUCKDB_TYPE_DATE:
@@ -404,6 +404,12 @@ void ScannerValue::Destroy() {
 		break;
 	case Params::TYPE_DECIMAL_AS_CHARS:
 		this->val.decimal_chars.~DecimalChars();
+		break;
+	case DUCKDB_TYPE_BLOB:
+		this->val.blob.~ScannerBlob();
+		break;
+	case DUCKDB_TYPE_UUID:
+		this->val.uuid.~ScannerUuid();
 		break;
 	default: {
 		// no-op


### PR DESCRIPTION
This PR fixes the destructor for `BLOB` and `UUID` parameters that could have caused a memory leak. Also fixes an UB for `UUID`.

Testing: problem is not exposed, `BLOB` and `UUID` parameters are covered by existing tests.