### PR TITLE
Better credentials filtering in error messages

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -41,10 +41,13 @@ static DbmsDriver ResolveDbmsDriver(const std::string &dbms_name, const std::str
 	}
 }
 
+// Note: we don't want to parse the connection string here,
+// if UID or PWD is escaped (starts with '{') - we are filtering out
+// everything until the end of the connection string
 static std::string FilterPwd(const std::string url) {
-	std::regex uid_pattern("UID=[^;]+", std::regex_constants::icase);
+	std::regex uid_pattern("UID=(\\{.*|[^;]+)", std::regex_constants::icase);
 	auto uid_filtered = std::regex_replace(url, uid_pattern, "UID=***");
-	std::regex pwd_pattern("PWD=[^;]+", std::regex_constants::icase);
+	std::regex pwd_pattern("PWD=(\\{.*|[^;]+)", std::regex_constants::icase);
 	return std::regex_replace(uid_filtered, pwd_pattern, "PWD=***");
 }
 


### PR DESCRIPTION
When connection error message is created, `UID=...` and `PWD=...` parts of connection string are filtered out.

When the credentials are escaped with `{`, the filtering logic was leaking parts of credentials after the first `;` in them.

This PR makes filtering logic more thorough.

Fixes: #160