### PR TITLE
Support DuckDB ODBC Scanner with MSSQL Authentication using a Azure Token

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -101,9 +101,8 @@ OdbcConnection::OdbcConnection(const std::string &url, const std::string &access
 		memcpy(access_token_buf.data(), &token_byte_len, sizeof(uint32_t));
 		memcpy(access_token_buf.data() + sizeof(uint32_t), wtoken.data(), token_byte_len);
 
-		SQLRETURN ret = SQLSetConnectAttrW(
-    								dbc, SQL_COPT_SS_ACCESS_TOKEN,
-    								reinterpret_cast<SQLPOINTER>(access_token_buf.data()), SQL_IS_POINTER);
+		SQLRETURN ret = SQLSetConnectAttrW(dbc, SQL_COPT_SS_ACCESS_TOKEN,
+		                                   reinterpret_cast<SQLPOINTER>(access_token_buf.data()), SQL_IS_POINTER);
 		if (!SQL_SUCCEEDED(ret)) {
 			std::string diag = Diagnostics::Read(dbc, SQL_HANDLE_DBC);
 			throw ScannerException("'SQLSetConnectAttrW' failed for SQL_COPT_SS_ACCESS_TOKEN, connection string: '" +

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -1,6 +1,7 @@
 #include "connection.hpp"
 
 #include <cstdint>
+#include <cstring>
 #include <regex>
 #include <vector>
 
@@ -10,6 +11,13 @@
 #include "registries.hpp"
 #include "scanner_exception.hpp"
 #include "widechar.hpp"
+
+// SQL_COPT_SS_ACCESS_TOKEN is a Microsoft SQL Server-specific pre-connect attribute
+// (value 1256, defined in msodbcsql.h).  We define it here so that the Microsoft
+// ODBC header is not a build dependency on non-Windows platforms.
+#ifndef SQL_COPT_SS_ACCESS_TOKEN
+#define SQL_COPT_SS_ACCESS_TOKEN 1256
+#endif
 
 namespace odbcscanner {
 
@@ -51,7 +59,7 @@ static std::string FilterPwd(const std::string url) {
 	return std::regex_replace(uid_filtered, pwd_pattern, "PWD=***");
 }
 
-OdbcConnection::OdbcConnection(const std::string &url) {
+OdbcConnection::OdbcConnection(const std::string &url, const std::string &access_token) {
 	{
 		SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, nullptr, &env);
 		if (!SQL_SUCCEEDED(ret)) {
@@ -73,6 +81,34 @@ OdbcConnection::OdbcConnection(const std::string &url) {
 		SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc);
 		if (!SQL_SUCCEEDED(ret)) {
 			throw ScannerException("'SQLAllocHandle' failed for DBC handle, return: " + std::to_string(ret));
+		}
+	}
+
+	// Set SQL_COPT_SS_ACCESS_TOKEN before connecting when an access token is provided.
+	// The Microsoft ODBC Driver for SQL Server requires the attribute value to point to an
+	// ACCESSTOKEN structure: a 4-byte unsigned integer holding the byte length of the token
+	// data, immediately followed by that many bytes of the token encoded in UTF-16LE.
+	// We build the structure in a local buffer that lives until after SQLDriverConnectW.
+	std::vector<unsigned char> access_token_buf;
+	if (!access_token.empty()) {
+		auto wtoken = WideChar::Widen(access_token.data(), access_token.length());
+		// wtoken.length<size_t>() = number of SQLWCHAR code units, WITHOUT the null terminator
+		size_t wtoken_len = wtoken.length<size_t>();
+		uint32_t token_byte_len = static_cast<uint32_t>(wtoken_len * sizeof(SQLWCHAR));
+
+		// Allocate: 4-byte size field + token bytes (no null terminator)
+		access_token_buf.resize(sizeof(uint32_t) + token_byte_len);
+		memcpy(access_token_buf.data(), &token_byte_len, sizeof(uint32_t));
+		memcpy(access_token_buf.data() + sizeof(uint32_t), wtoken.data(), token_byte_len);
+
+		SQLRETURN ret =
+		    SQLSetConnectAttrW(dbc, SQL_COPT_SS_ACCESS_TOKEN,
+		                       reinterpret_cast<SQLPOINTER>(access_token_buf.data()), SQL_IS_POINTER);
+		if (!SQL_SUCCEEDED(ret)) {
+			std::string diag = Diagnostics::Read(dbc, SQL_HANDLE_DBC);
+			throw ScannerException("'SQLSetConnectAttrW' failed for SQL_COPT_SS_ACCESS_TOKEN, connection string: '" +
+			                       FilterPwd(url) + "', return: " + std::to_string(ret) + ", diagnostics: '" + diag +
+			                       "'");
 		}
 	}
 
@@ -149,7 +185,7 @@ ExtractedConnection OdbcConnection::ExtractOrOpen(const std::string &function_na
 		throw ScannerException("'" + function_name +
 		                       "' error: invalid first argument specified, type ID: " + std::to_string(type_id) +
 		                       ", must be either 'BIGINT' as an output of 'odbc_connect()' (example: 'FROM "
-		                       "odbc_query(getvariable('conn'), ...)')" +
+		                       "odbc_query(getvariable(\'conn\'), ...)')" +
 		                       " or an ODBC connection string (for one-off queries)");
 	}
 

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -101,9 +101,9 @@ OdbcConnection::OdbcConnection(const std::string &url, const std::string &access
 		memcpy(access_token_buf.data(), &token_byte_len, sizeof(uint32_t));
 		memcpy(access_token_buf.data() + sizeof(uint32_t), wtoken.data(), token_byte_len);
 
-		SQLRETURN ret =
-		    SQLSetConnectAttrW(dbc, SQL_COPT_SS_ACCESS_TOKEN,
-		                       reinterpret_cast<SQLPOINTER>(access_token_buf.data()), SQL_IS_POINTER);
+		SQLRETURN ret = SQLSetConnectAttrW(
+    								dbc, SQL_COPT_SS_ACCESS_TOKEN,
+    								reinterpret_cast<SQLPOINTER>(access_token_buf.data()), SQL_IS_POINTER);
 		if (!SQL_SUCCEEDED(ret)) {
 			std::string diag = Diagnostics::Read(dbc, SQL_HANDLE_DBC);
 			throw ScannerException("'SQLSetConnectAttrW' failed for SQL_COPT_SS_ACCESS_TOKEN, connection string: '" +

--- a/src/functions/odbc_connect.cpp
+++ b/src/functions/odbc_connect.cpp
@@ -78,7 +78,7 @@ static void Connect(duckdb_function_info info, duckdb_data_chunk input, duckdb_v
 	//   (1)  odbc_connect(conn_string)
 	//   (2)  odbc_connect(conn_string, access_token)
 	//   (3)  odbc_connect(conn_string, username, password)
-	if (args_count < 1 || args_count > 4) {
+	if (args_count < 1 || args_count > 3) {
 		throw ScannerException(
 		    "'odbc_connect' error: invalid number of arguments specified, count: " + std::to_string(args_count) +
 		    ", supported signatures:"

--- a/src/functions/odbc_connect.cpp
+++ b/src/functions/odbc_connect.cpp
@@ -58,16 +58,33 @@ static void AppendUsernameAndPassword(duckdb_data_chunk input, std::string &conn
 	conn_str.append(";");
 }
 
+// Extract an optional access_token string from the given argument index.
+// Returns an empty string when the argument is absent or NULL.
+static std::string ExtractAccessToken(duckdb_data_chunk input, idx_t arg_idx) {
+	auto pair = Types::ExtractFunctionArg<std::string>(input, arg_idx);
+	if (pair.second) {
+		// NULL value - treat as "no token"
+		return "";
+	}
+	return pair.first;
+}
+
 static void Connect(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output) {
 	(void)info;
 
 	idx_t args_count = duckdb_data_chunk_get_column_count(input);
 
-	if (args_count != 1 && args_count != 3) {
+	// Supported call signatures:
+	//   (1)  odbc_connect(conn_string)
+	//   (2)  odbc_connect(conn_string, access_token)
+	//   (3)  odbc_connect(conn_string, username, password)
+	if (args_count < 1 || args_count > 4) {
 		throw ScannerException(
 		    "'odbc_connect' error: invalid number of arguments specified, count: " + std::to_string(args_count) +
-		    ", supported arguments: 'odbc_connect(conn_string: VARCHAR)', 'odbc_connect(conn_string: "
-		    "VARCHAR, username: VARCHAR, password: VARCHAR)'");
+		    ", supported signatures:"
+		    " odbc_connect(conn_string VARCHAR),"
+		    " odbc_connect(conn_string VARCHAR, access_token VARCHAR),"
+		    " odbc_connect(conn_string VARCHAR, username VARCHAR, password VARCHAR),");
 	}
 
 	auto conn_str_pair = Types::ExtractFunctionArg<std::string>(input, 0);
@@ -76,7 +93,13 @@ static void Connect(duckdb_function_info info, duckdb_data_chunk input, duckdb_v
 	}
 	std::string conn_str = conn_str_pair.first;
 
-	if (args_count == 3) {
+	std::string access_token;
+
+	if (args_count == 2) {
+		// Signature: (conn_string, access_token)
+		access_token = ExtractAccessToken(input, 1);
+	} else if (args_count == 3) {
+		// Signature: (conn_string, username, password)
 		AppendUsernameAndPassword(input, conn_str);
 	}
 
@@ -91,7 +114,7 @@ static void Connect(duckdb_function_info info, duckdb_data_chunk input, duckdb_v
 		}
 	}
 
-	auto oc_ptr = std_make_unique<OdbcConnection>(conn_str);
+	auto oc_ptr = std_make_unique<OdbcConnection>(conn_str, access_token);
 
 	int64_t *result_data = reinterpret_cast<int64_t *>(duckdb_vector_get_data(output));
 	result_data[0] = ConnectionsRegistry::Add(std::move(oc_ptr));

--- a/src/include/connection.hpp
+++ b/src/include/connection.hpp
@@ -33,7 +33,12 @@ struct OdbcConnection {
 	SQLHANDLE dbc = nullptr;
 	DbmsDriver driver;
 
-	OdbcConnection(const std::string &url);
+	// access_token is optional; when non-empty it is passed to the SQL Server ODBC driver via
+	// SQL_COPT_SS_ACCESS_TOKEN (connection attribute 1256) before the connection is opened.
+	// The token must be a raw OAuth/AAD bearer token string (UTF-8).  The driver requires it
+	// in UTF-16LE form preceded by a 4-byte byte-length field (the ACCESSTOKEN struct from
+	// msodbcsql.h); that encoding is handled internally.
+	OdbcConnection(const std::string &url, const std::string &access_token = "");
 	~OdbcConnection() noexcept;
 
 	OdbcConnection(OdbcConnection &other) = delete;

--- a/test/sql/connect.test
+++ b/test/sql/connect.test
@@ -32,6 +32,11 @@ Invalid Input Error: 'SQLDriverConnect' failed
 statement error
 SET VARIABLE conn = odbc_connect('Driver=fail', 'foo')
 ----
+Invalid Input Error: 'SQLDriverConnect' failed
+
+statement error
+SET VARIABLE conn = odbc_connect('Driver=fail', 'foo', 'bar', 'baz')
+----
 invalid number of arguments specified
 
 statement error


### PR DESCRIPTION
This pull request extends the existing ODBC connection with a access token which can be provided as a additional parameter. This is required for using duckdb with Azure SQL Servers running in CLI's where the provided ODBC Authentication methods of MSSQL are not sufficient and a access token needs to be provided.