### PR TITLE
Fix decimal_columns_as_chars user option

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -26,7 +26,7 @@ static DbmsDriver ResolveDbmsDriver(const std::string &dbms_name, const std::str
 		return DbmsDriver::ORACLE;
 	} else if (dbms_name == "Microsoft SQL Server") {
 		return DbmsDriver::MSSQL;
-	} else if (dbms_name.rfind("DB2/", 0) == 0) {
+	} else if (dbms_name.rfind("DB2", 0) == 0) {
 		return DbmsDriver::DB2;
 
 	} else if (dbms_name == "MariaDB") {

--- a/src/dbms_quirks.cpp
+++ b/src/dbms_quirks.cpp
@@ -75,7 +75,7 @@ DbmsQuirks::DbmsQuirks(OdbcConnection &conn, const std::map<std::string, ValuePt
 			continue;
 		}
 		if (en.first == "decimal_columns_as_chars") {
-			this->timestamp_columns_as_timestamp_ns = duckdb_get_bool(val.get());
+			this->decimal_columns_as_chars = duckdb_get_bool(val.get());
 		} else if (en.first == "decimal_columns_precision_through_ard") {
 			this->decimal_columns_precision_through_ard = duckdb_get_bool(val.get());
 		} else if (en.first == "decimal_columns_as_ard_type") {

--- a/test/sql/db2/07_decimal.test
+++ b/test/sql/db2/07_decimal.test
@@ -26,6 +26,12 @@ SELECT column_type from (
 ----
 DECIMAL(4,3)
 
+statement error
+SELECT * FROM odbc_query(getvariable('conn'), 'SELECT CAST(''1.234'' AS DECIMAL(4,3)) FROM sysibm.sysdummy1',
+  decimal_columns_as_chars=FALSE)
+----
+CLI0122E  Program type out of range. SQLSTATE=HY003
+
 query I
 SELECT * FROM odbc_query(getvariable('conn'), 'SELECT CAST(''123456.789'' AS DECIMAL(9,3)) FROM sysibm.sysdummy1')
 ----


### PR DESCRIPTION
This PR fixes a typo when user-specified `decimal_columns_as_chars` named parameter to `odbc_query()` was not actually set and default value for it was used instead.

Additionally it relaxes the name check for DB2 driver detection.

Fixes: #174