### PR TITLE
odbc_copy/odbc_query: bind NULL parameters with the source column's C type instead of SQL_C_DEFAULT

### DIFF
--- a/src/functions/odbc_copy.cpp
+++ b/src/functions/odbc_copy.cpp
@@ -286,11 +286,11 @@ struct SourceReader {
 			duckdb_vector vec = vectors.at(col_idx);
 			uint64_t *validity = validities.at(col_idx);
 			// todo: faster validity check
+			SourceColumn &fc = columns.at(col_idx);
 			if (validity == nullptr || duckdb_validity_row_is_valid(validity, row_idx)) {
-				SourceColumn &fc = columns.at(col_idx);
 				row[col_idx] = Types::ExtractNotNullParam(ctx.quirks, fc.type_id, vec, row_idx, col_idx);
 			} else {
-				row[col_idx] = ScannerValue();
+				row[col_idx] = ScannerValue::Null(fc.type_id);
 			}
 		}
 		this->row_idx++;

--- a/src/include/params.hpp
+++ b/src/include/params.hpp
@@ -23,6 +23,11 @@ namespace odbcscanner {
 // driver's numeric-write bug (duckdb/odbc-scanner#161 /
 // FirebirdSQL/firebird-odbc-driver#292) into catastrophic row loss, and it is
 // also the least efficient of the three common execute shapes.
+//
+// A SQLNULL slot needs no separate entry for the NULL's column type (which now
+// selects its C type): within one prepared statement a slot index always maps to
+// the same source column, and the cache is Reset() whenever the statement
+// changes, so a slot's NULL C type cannot change while a cached shape stands.
 struct BindSlotShape {
 	param_type type_id = DUCKDB_TYPE_INVALID;
 	SQLSMALLINT expected_type = SQL_PARAM_TYPE_UNKNOWN;

--- a/src/include/scanner_value.hpp
+++ b/src/include/scanner_value.hpp
@@ -21,6 +21,10 @@ class ScannerValue {
 	param_type type_id = DUCKDB_TYPE_INVALID;
 	SQLLEN len_bytes = 0;
 	SQLSMALLINT expected_type = SQL_PARAM_TYPE_UNKNOWN;
+	// Only meaningful when type_id is DUCKDB_TYPE_SQLNULL: the DuckDB type of the
+	// column this NULL came from, used to bind it with the same C type the
+	// column's non-NULL values use. DUCKDB_TYPE_INVALID means "unknown".
+	param_type null_column_type = DUCKDB_TYPE_INVALID;
 
 	union InternalValue {
 		bool null_val;
@@ -136,6 +140,12 @@ public:
 	explicit ScannerValue(SqlBit value);
 	explicit ScannerValue(SQLGUID value);
 
+	// A SQL NULL parameter that remembers the DuckDB type of its source column.
+	// Prefer this over the default constructor wherever the column type is known:
+	// it is what lets Types::NullCType bind the NULL with the column's own C type
+	// instead of SQL_C_DEFAULT.
+	static ScannerValue Null(param_type column_type_id);
+
 	ScannerValue(ScannerValue &other) = delete;
 	ScannerValue(ScannerValue &&other);
 
@@ -157,6 +167,8 @@ public:
 	void SetLengthBytes(SQLLEN value);
 
 	SQLSMALLINT ExpectedType();
+
+	param_type NullColumnType();
 
 	void SetExpectedType(SQLSMALLINT expected_type_in);
 

--- a/src/include/types.hpp
+++ b/src/include/types.hpp
@@ -46,6 +46,19 @@ struct Types {
 
 	static bool IsWideCharacterSQLType(SQLSMALLINT t);
 
+	// TINYINT..UBIGINT: the parameter types Types::CoalesceParameterType turns into
+	// DECIMAL under the integral_params_as_decimals quirk.
+	static bool IsIntegralParamType(param_type t);
+
+	// IsIntegralParamType plus FLOAT and DOUBLE: the parameter types
+	// Params::SetExpectedTypes stringifies when the target column is a character
+	// type. Single source of truth for that set — Types::NullCType has to mirror
+	// both coalescing steps to pick a NULL's C type.
+	static bool IsNumericParamType(param_type t);
+
+	// The C type to bind a NULL parameter of a `column_type` column with.
+	static SQLSMALLINT NullCType(DbmsQuirks &quirks, param_type column_type, SQLSMALLINT expected_type);
+
 	static const SQLSMALLINT SQL_SS_TIME2 = -154;
 	static const SQLSMALLINT SQL_SS_TIMESTAMPOFFSET = -155;
 

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -63,14 +63,17 @@ std::vector<ScannerValue> Params::Extract(DbmsQuirks &quirks, duckdb_data_chunk 
 			    ", column: " + std::to_string(col_idx) + ", columns count: " + std::to_string(col_count));
 		}
 
+		// Resolved before the NULL check: a NULL parameter is bound with its
+		// column's own C type, so it needs the STRUCT field's declared type too.
+		auto child_type = LogicalTypePtr(duckdb_struct_type_child_type(struct_type.get(), i), LogicalTypeDeleter);
+		auto child_type_id = duckdb_get_type_id(child_type.get());
+
 		uint64_t *child_validity = duckdb_vector_get_validity(child_vec);
 		if (child_validity != nullptr && !duckdb_validity_row_is_valid(child_validity, 0)) {
-			params.emplace_back(ScannerValue());
+			params.emplace_back(ScannerValue::Null(child_type_id));
 			continue;
 		}
 
-		auto child_type = LogicalTypePtr(duckdb_struct_type_child_type(struct_type.get(), i), LogicalTypeDeleter);
-		auto child_type_id = duckdb_get_type_id(child_type.get());
 		ScannerValue sp = Types::ExtractNotNullParam(quirks, child_type_id, child_vec, 0, i);
 		params.emplace_back(std::move(sp));
 	}
@@ -91,9 +94,14 @@ std::vector<ScannerValue> Params::Extract(DbmsQuirks &quirks, duckdb_value struc
 
 	std::vector<ScannerValue> params;
 	for (idx_t i = 0; i < params_count; i++) {
+		// The STRUCT's declared field type, not the child value's own type: a NULL
+		// value reports DUCKDB_TYPE_SQLNULL, which carries no column information.
+		auto child_type = LogicalTypePtr(duckdb_struct_type_child_type(struct_type, i), LogicalTypeDeleter);
+		auto child_type_id = duckdb_get_type_id(child_type.get());
+
 		auto child_val = ValuePtr(duckdb_get_struct_child(struct_value, i), ValueDeleter);
 		if (duckdb_is_null_value(child_val.get())) {
-			params.emplace_back(ScannerValue());
+			params.emplace_back(ScannerValue::Null(child_type_id));
 			continue;
 		}
 
@@ -145,21 +153,8 @@ static void CoalesceNumericToCharsIfNeeded(ScannerValue &param) {
 	if (!Types::IsCharacterSQLType(param.ExpectedType())) {
 		return;
 	}
-	switch (param.ParamType()) {
-	case DUCKDB_TYPE_TINYINT:
-	case DUCKDB_TYPE_UTINYINT:
-	case DUCKDB_TYPE_SMALLINT:
-	case DUCKDB_TYPE_USMALLINT:
-	case DUCKDB_TYPE_INTEGER:
-	case DUCKDB_TYPE_UINTEGER:
-	case DUCKDB_TYPE_BIGINT:
-	case DUCKDB_TYPE_UBIGINT:
-	case DUCKDB_TYPE_FLOAT:
-	case DUCKDB_TYPE_DOUBLE:
+	if (Types::IsNumericParamType(param.ParamType())) {
 		param.TransformNumericToChars();
-		break;
-	default:
-		break;
 	}
 }
 

--- a/src/scanner_value.cpp
+++ b/src/scanner_value.cpp
@@ -158,6 +158,12 @@ SQLGUID &ScannerValue::Value<SQLGUID>() {
 ScannerValue::ScannerValue() : type_id(DUCKDB_TYPE_SQLNULL), len_bytes(SQL_NULL_DATA) {
 }
 
+ScannerValue ScannerValue::Null(param_type column_type_id) {
+	ScannerValue res;
+	res.null_column_type = column_type_id;
+	return res;
+}
+
 ScannerValue::ScannerValue(bool value) : type_id(DUCKDB_TYPE_BOOLEAN), len_bytes(sizeof(value)), val(value) {
 }
 
@@ -419,7 +425,8 @@ void ScannerValue::Destroy() {
 }
 
 ScannerValue::ScannerValue(ScannerValue &&other)
-    : type_id(other.type_id), len_bytes(other.len_bytes), expected_type(other.expected_type) {
+    : type_id(other.type_id), len_bytes(other.len_bytes), expected_type(other.expected_type),
+      null_column_type(other.null_column_type) {
 	AssignByType(type_id, this->val, other);
 }
 
@@ -428,6 +435,7 @@ ScannerValue &ScannerValue::operator=(ScannerValue &&other) {
 	this->type_id = other.type_id;
 	this->len_bytes = other.len_bytes;
 	this->expected_type = other.expected_type;
+	this->null_column_type = other.null_column_type;
 	AssignByType(type_id, this->val, other);
 	return *this;
 }
@@ -463,6 +471,10 @@ void ScannerValue::SetLengthBytes(SQLLEN value) {
 
 SQLSMALLINT ScannerValue::ExpectedType() {
 	return expected_type;
+}
+
+param_type ScannerValue::NullColumnType() {
+	return null_column_type;
 }
 
 void ScannerValue::SetExpectedType(SQLSMALLINT expected_type_in) {

--- a/src/types/null_type.cpp
+++ b/src/types/null_type.cpp
@@ -7,16 +7,21 @@ DUCKDB_EXTENSION_EXTERN
 
 namespace odbcscanner {
 
+// Binds SQL NULL with the C type of the column the NULL came from, so that a
+// parameter slot keeps one C type across NULL and non-NULL rows. Only the C type
+// changes: the ODBC spec ignores the data pointer and buffer length when the
+// indicator is SQL_NULL_DATA, so they stay as they were.
 template <>
 void TypeSpecific::BindOdbcParam<std::nullptr_t>(QueryContext &ctx, ScannerValue &param, SQLSMALLINT param_idx) {
-	SQLRETURN ret = SQLBindParameter(ctx.hstmt(), param_idx, SQL_PARAM_INPUT, SQL_C_DEFAULT, param.ExpectedType(), 1, 0,
+	SQLSMALLINT ctype = Types::NullCType(ctx.quirks, param.NullColumnType(), param.ExpectedType());
+	SQLRETURN ret = SQLBindParameter(ctx.hstmt(), param_idx, SQL_PARAM_INPUT, ctype, param.ExpectedType(), 1, 0,
 	                                 nullptr, 0, &param.LengthBytes());
 	if (!SQL_SUCCEEDED(ret)) {
 		std::string diag = Diagnostics::Read(ctx.hstmt(), SQL_HANDLE_STMT);
-		throw ScannerException(
-		    "'SQLBindParameter' NULL failed, expected type: " + std::to_string(param.ExpectedType()) +
-		    " index: " + std::to_string(param_idx) + ", query: '" + ctx.query + "', return: " + std::to_string(ret) +
-		    ", diagnostics: '" + diag + "'");
+		throw ScannerException("'SQLBindParameter' NULL failed, C type: " + std::to_string(ctype) +
+		                       ", expected type: " + std::to_string(param.ExpectedType()) +
+		                       " index: " + std::to_string(param_idx) + ", query: '" + ctx.query +
+		                       "', return: " + std::to_string(ret) + ", diagnostics: '" + diag + "'");
 	}
 }
 

--- a/src/types/types.cpp
+++ b/src/types/types.cpp
@@ -41,6 +41,104 @@ bool Types::IsWideCharacterSQLType(SQLSMALLINT t) {
 	return t == SQL_WCHAR || t == SQL_WVARCHAR || t == SQL_WLONGVARCHAR;
 }
 
+bool Types::IsIntegralParamType(param_type t) {
+	switch (t) {
+	case DUCKDB_TYPE_TINYINT:
+	case DUCKDB_TYPE_UTINYINT:
+	case DUCKDB_TYPE_SMALLINT:
+	case DUCKDB_TYPE_USMALLINT:
+	case DUCKDB_TYPE_INTEGER:
+	case DUCKDB_TYPE_UINTEGER:
+	case DUCKDB_TYPE_BIGINT:
+	case DUCKDB_TYPE_UBIGINT:
+		return true;
+	default:
+		return false;
+	}
+}
+
+bool Types::IsNumericParamType(param_type t) {
+	return IsIntegralParamType(t) || t == DUCKDB_TYPE_FLOAT || t == DUCKDB_TYPE_DOUBLE;
+}
+
+// The C type a NULL parameter of a `column_type` column must be bound with: the
+// same one the column's non-NULL values get, so that a parameter slot keeps a
+// single C type across NULL and non-NULL rows.
+//
+// Each arm mirrors a BindOdbcParam specialization in this directory, after the
+// two coalescing steps Params::SetExpectedTypes applies to a value before
+// binding it. Order matters and follows SetExpectedTypes: an integral is turned
+// into a DECIMAL first (Types::CoalesceParameterType), and only a value that is
+// still integral or floating point is then stringified for a character target
+// (CoalesceNumericToCharsIfNeeded).
+//
+// Unknown and unmapped column types keep SQL_C_DEFAULT, which is what every NULL
+// used to bind with. That is safe as long as the values of the same column bind
+// with the driver's default C type too; it is precisely when they do not that a
+// NULL can re-type the parameter. Drivers may legitimately change a parameter's
+// transfer type on a character bind, and SQL_C_DEFAULT resolves to a character
+// type for SQL_NUMERIC / SQL_DECIMAL / SQL_BIGINT, so on the Firebird ODBC driver
+// a NULL rewrote the prepared statement's parameter descriptor and every value
+// bound into that slot afterwards was silently stored as NULL
+// (FirebirdSQL/firebird-odbc-driver#300).
+SQLSMALLINT Types::NullCType(DbmsQuirks &quirks, param_type column_type, SQLSMALLINT expected_type) {
+	SQLSMALLINT chars_type = IsWideCharacterSQLType(expected_type) ? SQL_C_WCHAR : SQL_C_CHAR;
+
+	if (IsIntegralParamType(column_type) && quirks.integral_params_as_decimals && !quirks.decimal_params_as_chars) {
+		return SQL_C_NUMERIC;
+	}
+	if (IsNumericParamType(column_type) && IsCharacterSQLType(expected_type)) {
+		return chars_type;
+	}
+
+	switch (column_type) {
+	case DUCKDB_TYPE_BOOLEAN:
+		return SQL_C_BIT;
+	case DUCKDB_TYPE_TINYINT:
+		return SQL_C_STINYINT;
+	case DUCKDB_TYPE_UTINYINT:
+		return SQL_C_UTINYINT;
+	case DUCKDB_TYPE_SMALLINT:
+		return SQL_C_SSHORT;
+	case DUCKDB_TYPE_USMALLINT:
+		return SQL_C_USHORT;
+	case DUCKDB_TYPE_INTEGER:
+		return SQL_C_SLONG;
+	case DUCKDB_TYPE_UINTEGER:
+		return SQL_C_ULONG;
+	case DUCKDB_TYPE_BIGINT:
+		return SQL_C_SBIGINT;
+	case DUCKDB_TYPE_UBIGINT:
+		return SQL_C_UBIGINT;
+	case DUCKDB_TYPE_FLOAT:
+		return SQL_C_FLOAT;
+	case DUCKDB_TYPE_DOUBLE:
+		return SQL_C_DOUBLE;
+	case DUCKDB_TYPE_DECIMAL:
+		// ExtractNotNullParam<duckdb_decimal> picks the representation from this
+		// same quirk: DecimalChars (character) or SQL_NUMERIC_STRUCT.
+		return quirks.decimal_params_as_chars ? chars_type : SQL_C_NUMERIC;
+	case DUCKDB_TYPE_VARCHAR:
+		return SQL_C_WCHAR;
+	case DUCKDB_TYPE_BLOB:
+		return SQL_C_BINARY;
+	case DUCKDB_TYPE_UUID:
+		return SQL_C_GUID;
+	case DUCKDB_TYPE_DATE:
+		return SQL_C_TYPE_DATE;
+	case DUCKDB_TYPE_TIME:
+		return quirks.time_params_as_ss_time2 ? SQL_C_BINARY : SQL_C_TYPE_TIME;
+	case DUCKDB_TYPE_TIMESTAMP:
+	case DUCKDB_TYPE_TIMESTAMP_TZ:
+	case DUCKDB_TYPE_TIMESTAMP_NS:
+		// TIMESTAMP_NS values are extracted into a TimestampNsStruct, which is a
+		// DUCKDB_TYPE_TIMESTAMP parameter and binds as SQL_C_TYPE_TIMESTAMP.
+		return SQL_C_TYPE_TIMESTAMP;
+	default:
+		return SQL_C_DEFAULT;
+	}
+}
+
 ScannerValue Types::ExtractNotNullParam(DbmsQuirks &quirks, duckdb_type type_id, duckdb_vector vec, idx_t row_idx,
                                         idx_t param_idx) {
 	switch (type_id) {

--- a/test/sql/duckdb/duckdb_copy.test
+++ b/test/sql/duckdb/duckdb_copy.test
@@ -154,5 +154,90 @@ SELECT * FROM odbc_query(getvariable('conn'),
 statement ok
 SELECT * FROM odbc_query(getvariable('conn'), 'DROP TABLE duckdb_bind_once')
 
+# NULL parameter followed by a value in the same parameter slot
+# (driver-independent half of the regression test for
+# FirebirdSQL/firebird-odbc-driver#300).
+#
+# NULL parameters are bound with the source column's own C type instead of
+# SQL_C_DEFAULT, so a slot keeps one C type across NULL and non-NULL rows rather
+# than alternating between the driver's default character type for a NULL and a
+# numeric type for the value. The Firebird ODBC driver silently dropped every
+# value that followed a NULL on NUMERIC / DECIMAL / BIGINT parameters because of
+# that alternation (see test/sql/firebird/firebird_copy.test); this block passes
+# on the DuckDB ODBC driver before and after the change and keeps the typed-NULL
+# bind path covered — with one column per bound C type — in every CI job.
+#
+# The DECIMAL column deliberately uses values with non-zero fractional digits:
+# whole-number DECIMAL parameters (60.00) come back from the DuckDB ODBC driver
+# scaled down to 0.60, with or without NULLs in the source — a separate,
+# pre-existing issue that this block is not about.
+
+statement ok
+SELECT * FROM odbc_query(getvariable('conn'), 'DROP TABLE IF EXISTS duckdb_null_params')
+
+statement ok
+SELECT * FROM odbc_query(getvariable('conn'),
+  'CREATE TABLE duckdb_null_params (
+    id INTEGER NOT NULL,
+    v_decimal DECIMAL(18,2),
+    v_bigint BIGINT,
+    v_integer INTEGER,
+    v_double DOUBLE,
+    v_varchar VARCHAR,
+    v_date DATE
+  )')
+
+# single-row path, NULL in the first row
+
+query II
+SELECT completed, rows_processed FROM odbc_copy(getvariable('conn'),
+  dest_table='duckdb_null_params',
+  batch_size=1,
+  source_query='SELECT * FROM (VALUES
+      (1, NULL::DECIMAL(18,2), NULL::BIGINT, NULL::INTEGER, NULL::DOUBLE, NULL::VARCHAR, NULL::DATE),
+      (2, 60.25::DECIMAL(18,2), 60::BIGINT, 60::INTEGER, 60::DOUBLE, ''s2'', DATE ''2024-03-01'')
+    ) t(id, v_decimal, v_bigint, v_integer, v_double, v_varchar, v_date) ORDER BY id')
+----
+1	2
+
+query IIIIIII
+SELECT * FROM odbc_query(getvariable('conn'),
+  'SELECT id, v_decimal, v_bigint, v_integer, v_double, v_varchar, v_date FROM duckdb_null_params ORDER BY id')
+----
+1	NULL	NULL	NULL	NULL	NULL	NULL
+2	60.25	60	60	60.0	s2	2024-03-01
+
+statement ok
+SELECT * FROM odbc_query(getvariable('conn'), 'DELETE FROM duckdb_null_params')
+
+# batched multi-row VALUES path: with batch_size=2 the first execute binds
+# (NULL, 60) and the second (61, 62), so the first row's slots go NULL → value
+# between two executes of one prepared statement.
+
+query II
+SELECT completed, rows_processed FROM odbc_copy(getvariable('conn'),
+  dest_table='duckdb_null_params',
+  batch_size=2,
+  source_query='SELECT * FROM (VALUES
+      (1, NULL::DECIMAL(18,2), NULL::BIGINT, NULL::INTEGER, NULL::DOUBLE, NULL::VARCHAR, NULL::DATE),
+      (2, 60.25::DECIMAL(18,2), 60::BIGINT, 60::INTEGER, 60::DOUBLE, ''s2'', DATE ''2024-03-01''),
+      (3, 61.25::DECIMAL(18,2), 61::BIGINT, 61::INTEGER, 61::DOUBLE, ''s3'', DATE ''2024-03-02''),
+      (4, 62.25::DECIMAL(18,2), 62::BIGINT, 62::INTEGER, 62::DOUBLE, ''s4'', DATE ''2024-03-03'')
+    ) t(id, v_decimal, v_bigint, v_integer, v_double, v_varchar, v_date) ORDER BY id')
+----
+1	4
+
+query IIIIIII
+SELECT * FROM odbc_query(getvariable('conn'),
+  'SELECT id, v_decimal, v_bigint, v_integer, v_double, v_varchar, v_date FROM duckdb_null_params ORDER BY id')
+----
+1	NULL	NULL	NULL	NULL	NULL	NULL
+2	60.25	60	60	60.0	s2	2024-03-01
+3	61.25	61	61	61.0	s3	2024-03-02
+4	62.25	62	62	62.0	s4	2024-03-03
+
+statement ok
+SELECT * FROM odbc_query(getvariable('conn'), 'DROP TABLE duckdb_null_params')
+
 statement ok
 SELECT odbc_close(getvariable('conn'))

--- a/test/sql/firebird/firebird_copy.test
+++ b/test/sql/firebird/firebird_copy.test
@@ -435,5 +435,183 @@ SELECT * FROM odbc_query(getvariable('conn'),
 statement ok
 SELECT * FROM odbc_query(getvariable('conn'), 'DROP TABLE INT_TO_VARCHAR_PK')
 
+# NULL parameter followed by a value on a NUMERIC / DECIMAL / BIGINT column
+# (regression test for FirebirdSQL/firebird-odbc-driver#300)
+#
+# NULL parameters used to be bound with SQL_C_DEFAULT, which leaves the C type
+# up to the driver. The ODBC-spec default for SQL_NUMERIC, SQL_DECIMAL and
+# SQL_BIGINT is a *character* type, so a numeric column's parameter slot
+# alternated between a character bind (NULL rows) and a numeric bind (value
+# rows) inside a single prepared statement. On the Firebird ODBC driver the
+# character bind rewrites the prepared XSQLVAR to SQL_TEXT and nothing restores
+# it, so every value bound after a NULL in that slot was silently stored as
+# NULL — every driver call returned SQL_SUCCESS and the row counts were right.
+#
+# NULLs now carry the source column's own C type, so a slot's C type no longer
+# changes between NULL and non-NULL rows. INTEGER targets never lost data and
+# are kept here as a control column.
+
+statement ok
+SELECT * FROM odbc_query(getvariable('conn'), 'DROP TABLE NULL_PARAM_TYPES', ignore_exec_failure=TRUE)
+
+statement ok
+SELECT * FROM odbc_query(getvariable('conn'),
+  'CREATE TABLE NULL_PARAM_TYPES (
+    id INTEGER NOT NULL PRIMARY KEY,
+    v_numeric NUMERIC(9,3),
+    v_decimal DECIMAL(18,2),
+    v_bigint BIGINT,
+    v_integer INTEGER
+  )')
+
+# INTEGER source, NULL in the first row, single-row path (batch_size=1) — the
+# shape that lost roughly 485k values in a production merge.
+
+query II
+SELECT completed, rows_processed FROM odbc_copy(getvariable('conn'),
+  dest_table='NULL_PARAM_TYPES',
+  batch_size=1,
+  column_quotes='',
+  source_query='SELECT * FROM (VALUES
+      (1, NULL::INTEGER, NULL::INTEGER, NULL::INTEGER, NULL::INTEGER),
+      (2, 60::INTEGER, 60::INTEGER, 60::INTEGER, 60::INTEGER)
+    ) t(id, v_numeric, v_decimal, v_bigint, v_integer) ORDER BY id')
+----
+1	2
+
+query IIIII
+SELECT * FROM odbc_query(getvariable('conn'),
+  'SELECT id, v_numeric, v_decimal, v_bigint, v_integer FROM NULL_PARAM_TYPES ORDER BY id')
+----
+1	NULL	NULL	NULL	NULL
+2	60.0	60.0	60	60
+
+statement ok
+SELECT * FROM odbc_query(getvariable('conn'), 'DELETE FROM NULL_PARAM_TYPES')
+
+# Same columns through the batched multi-row VALUES path: with batch_size=2 the
+# first execute binds (NULL, 60) and the second (61, 62), so the first row's
+# parameter slots go NULL → value between two executes of one prepared
+# statement — the batched equivalent of the transition above.
+
+query II
+SELECT completed, rows_processed FROM odbc_copy(getvariable('conn'),
+  dest_table='NULL_PARAM_TYPES',
+  batch_size=2,
+  column_quotes='',
+  source_query='SELECT * FROM (VALUES
+      (1, NULL::INTEGER, NULL::INTEGER, NULL::INTEGER, NULL::INTEGER),
+      (2, 60::INTEGER, 60::INTEGER, 60::INTEGER, 60::INTEGER),
+      (3, 61::INTEGER, 61::INTEGER, 61::INTEGER, 61::INTEGER),
+      (4, 62::INTEGER, 62::INTEGER, 62::INTEGER, 62::INTEGER)
+    ) t(id, v_numeric, v_decimal, v_bigint, v_integer) ORDER BY id')
+----
+1	4
+
+query IIIII
+SELECT * FROM odbc_query(getvariable('conn'),
+  'SELECT id, v_numeric, v_decimal, v_bigint, v_integer FROM NULL_PARAM_TYPES ORDER BY id')
+----
+1	NULL	NULL	NULL	NULL
+2	60.0	60.0	60	60
+3	61.0	61.0	61	61
+4	62.0	62.0	62	62
+
+statement ok
+SELECT * FROM odbc_query(getvariable('conn'), 'DELETE FROM NULL_PARAM_TYPES')
+
+# DOUBLE source (SQL_C_DOUBLE values) with the NULL between two values, so each
+# slot transitions value → NULL → value.
+
+query II
+SELECT completed, rows_processed FROM odbc_copy(getvariable('conn'),
+  dest_table='NULL_PARAM_TYPES',
+  batch_size=1,
+  column_quotes='',
+  source_query='SELECT * FROM (VALUES
+      (1, 60::DOUBLE, 60::DOUBLE, 60::DOUBLE, 60::DOUBLE),
+      (2, NULL::DOUBLE, NULL::DOUBLE, NULL::DOUBLE, NULL::DOUBLE),
+      (3, 61::DOUBLE, 61::DOUBLE, 61::DOUBLE, 61::DOUBLE)
+    ) t(id, v_numeric, v_decimal, v_bigint, v_integer) ORDER BY id')
+----
+1	3
+
+query IIIII
+SELECT * FROM odbc_query(getvariable('conn'),
+  'SELECT id, v_numeric, v_decimal, v_bigint, v_integer FROM NULL_PARAM_TYPES ORDER BY id')
+----
+1	60.0	60.0	60	60
+2	NULL	NULL	NULL	NULL
+3	61.0	61.0	61	61
+
+statement ok
+SELECT * FROM odbc_query(getvariable('conn'), 'DELETE FROM NULL_PARAM_TYPES')
+
+# DECIMAL source: the scanner already binds these as characters on Firebird
+# (the decimal_params_as_chars quirk), so the slot's C type never changed and
+# this shape passed before the fix as well. Kept as a control.
+
+query II
+SELECT completed, rows_processed FROM odbc_copy(getvariable('conn'),
+  dest_table='NULL_PARAM_TYPES',
+  batch_size=1,
+  column_quotes='',
+  source_query='SELECT * FROM (VALUES
+      (1, NULL::DECIMAL(9,3), NULL::DECIMAL(18,2), NULL::DECIMAL(18,0), NULL::DECIMAL(9,0)),
+      (2, 60::DECIMAL(9,3), 60::DECIMAL(18,2), 60::DECIMAL(18,0), 60::DECIMAL(9,0))
+    ) t(id, v_numeric, v_decimal, v_bigint, v_integer) ORDER BY id')
+----
+1	2
+
+query IIIII
+SELECT * FROM odbc_query(getvariable('conn'),
+  'SELECT id, v_numeric, v_decimal, v_bigint, v_integer FROM NULL_PARAM_TYPES ORDER BY id')
+----
+1	NULL	NULL	NULL	NULL
+2	60.0	60.0	60	60
+
+statement ok
+SELECT * FROM odbc_query(getvariable('conn'), 'DROP TABLE NULL_PARAM_TYPES')
+
+# Typed NULLs on the non-numeric branches of the C-type mapping: an INTEGER
+# source bound to a character column (the scanner stringifies those, so the NULL
+# must use a character C type too), a VARCHAR source and a DATE source. These
+# passed before the fix; they guard the rest of the mapping against a wrong C
+# type being chosen for the NULL.
+
+statement ok
+SELECT * FROM odbc_query(getvariable('conn'), 'DROP TABLE NULL_PARAM_MIXED', ignore_exec_failure=TRUE)
+
+statement ok
+SELECT * FROM odbc_query(getvariable('conn'),
+  'CREATE TABLE NULL_PARAM_MIXED (
+    id INTEGER NOT NULL PRIMARY KEY,
+    v_int_to_char VARCHAR(10),
+    v_char VARCHAR(10),
+    v_date DATE
+  )')
+
+query II
+SELECT completed, rows_processed FROM odbc_copy(getvariable('conn'),
+  dest_table='NULL_PARAM_MIXED',
+  batch_size=1,
+  column_quotes='',
+  source_query='SELECT * FROM (VALUES
+      (1, NULL::INTEGER, NULL::VARCHAR, NULL::DATE),
+      (2, 60::INTEGER, ''s2'', DATE ''2024-03-01'')
+    ) t(id, v_int_to_char, v_char, v_date) ORDER BY id')
+----
+1	2
+
+query IIII
+SELECT * FROM odbc_query(getvariable('conn'),
+  'SELECT id, v_int_to_char, v_char, v_date FROM NULL_PARAM_MIXED ORDER BY id')
+----
+1	NULL	NULL	NULL
+2	60	s2	2024-03-01
+
+statement ok
+SELECT * FROM odbc_query(getvariable('conn'), 'DROP TABLE NULL_PARAM_MIXED')
+
 statement ok
 SELECT odbc_close(getvariable('conn'))


### PR DESCRIPTION
## Problem

`odbc_copy` binds a NULL parameter with `SQL_C_DEFAULT`, which hands the choice of C type to the driver. The ODBC-spec default for `SQL_NUMERIC` / `SQL_DECIMAL` / `SQL_BIGINT` is a **character** type, so a numeric column's parameter slot alternates between a character bind (NULL rows) and a numeric bind (value rows) inside one prepared statement.

On the Firebird ODBC driver that alternation is destructive: **every value bound into a slot after a NULL is silently stored as NULL**. `SQL_SUCCESS` from every call, correct `rows_processed`, no diagnostics. Found in production, where a `NUMERIC(9,3)` column stayed NULL on ~485,000 rows after a merge whose source had NULLs first.

Measured through `odbc_copy` (source `VALUES (1, NULL::T), (2, 60::T)`, one prepared statement):

| DuckDB source type | Firebird target | NULL then value | value then NULL |
|---|---|---|---|
| INTEGER / SMALLINT / BIGINT / DOUBLE | NUMERIC(9,3) | **LOST** | ok |
| INTEGER / BIGINT / DOUBLE | BIGINT | **LOST** | ok |
| DECIMAL / VARCHAR | NUMERIC(9,3), BIGINT, INTEGER, SMALLINT, DOUBLE | ok | ok |
| INTEGER / SMALLINT / BIGINT | INTEGER, SMALLINT | ok | ok |
| INTEGER / DECIMAL / DOUBLE | DOUBLE PRECISION | ok | ok |
| VARCHAR / INTEGER | VARCHAR(10) | ok | ok |
| DATE | DATE | ok | ok |

Both `odbc_copy` paths lose data: the single-row (`batch_size=1`) path and the batched multi-row `VALUES` path. Reproduced on Firebird ODBC 3.0.1.21 (the version this repo's CI installs), 3.5.0-rc1, and a current 3.5 development build.

Driver-side root cause, filed as [FirebirdSQL/firebird-odbc-driver#300](https://github.com/FirebirdSQL/firebird-odbc-driver/issues/300) (reported independently by a third party on Linux/unixODBC/Firebird 5, so it is not Windows-specific); [detailed analysis in this comment](https://github.com/FirebirdSQL/firebird-odbc-driver/issues/300#issuecomment-5560317970). In short: `SQL_C_DEFAULT` resolves to `SQL_C_CHAR` for those SQL types, the character bind makes the driver call `setTypeText()` on the **prepared** `XSQLVAR`, nothing restores it, and the next `SQLBindParameter` on that index re-describes the parameter from the mutated var and picks a `conv<Long|Bigint|Double>ToString` converter for what is still a NUMERIC/BIGINT parameter.

## Why fix it in the scanner

A driver fix is coming separately, but old drivers stay deployed for years — the same argument made in #161 — so the scanner should not depend on it.

More importantly this is not purely a driver bug. The scanner *chooses* `SQL_C_DEFAULT`, and `SQL_C_DEFAULT` means "driver, pick the C type". Drivers are allowed to change a parameter's transfer type on a character bind. The scanner knows the source column's type and has no reason to induce a character/numeric flip on a slot whose values it binds numerically.

This is the same spirit as #164 (stringify numerics for character targets in the scanner rather than lean on a driver conversion path) and #168 (keep one stable bind shape per slot).

## The change

- `ScannerValue::Null(column_type)` — a SQL NULL that remembers the DuckDB type of the column it came from. `type_id` stays `DUCKDB_TYPE_SQLNULL` and `len_bytes` stays `SQL_NULL_DATA`, so every existing NULL check is untouched.
- The three sites that create NULL parameters pass the column type: `SourceReader::ReadRow` in `odbc_copy`, and both `Params::Extract` overloads (the STRUCT field's *declared* type, since a NULL value's own type is `SQLNULL`).
- `Types::NullCType(quirks, column_type, expected_type)` — the C type the column's non-NULL values are bound with. Each arm mirrors a `BindOdbcParam` specialization and replays the two coalescing steps `Params::SetExpectedTypes` applies to a value, in the same order (integrals become DECIMAL under `integral_params_as_decimals` first, and only a still-numeric value is then stringified for a character target). The numeric-type set the two sides share is now `Types::IsNumericParamType`, so they cannot drift apart.
- `BindOdbcParam<std::nullptr_t>` uses it.

**Only the C type changes.** The SQL type, `ColumnSize=1`, `DecimalDigits=0`, the NULL data pointer and the zero buffer length are exactly as before — the ODBC spec ignores the data pointer when the indicator is `SQL_NULL_DATA`, and today's argument shape is already proven across every driver in CI.

No behaviour change when the column type is unknown or unmapped: those keep `SQL_C_DEFAULT`. The bind cache is untouched — a NULL slot and a value slot still have different shapes and still rebind on each transition, but now with a stable C type.

## Evidence

Raw ODBC through `odbc32.dll`, no DuckDB involved, one prepared `UPDATE OR INSERT`, rows `(1, NULL)` then `(2, 60)`, reading row 2 back:

| shape | NUMERIC(9,3) | DECIMAL(18,2) | BIGINT | INTEGER | SMALLINT | DOUBLE |
|---|---|---|---|---|---|---|
| **A** NULL as `SQL_C_DEFAULT` + described SQL type, then `SQL_C_SLONG` — *before* | **NULL** | **NULL** | **NULL** | ok | ok | ok |
| **B** NULL as `SQL_C_SLONG`/`SQL_INTEGER` with a real buffer, then `SQL_C_SLONG` | ok | ok | ok | ok | ok | ok |
| **C** as A, plus `SQL_RESET_PARAMS` and a full rebind before row 2 | **NULL** | **NULL** | **NULL** | ok | ok | ok |
| **D** bound once as `SQL_C_SLONG`, only buffer and indicator change | ok | ok | ok | ok | ok | ok |
| **E** NULL as `SQL_C_SLONG` + described SQL type, `ColumnSize=1`, `ptr=NULL` — *after* | ok | ok | ok | ok | ok | ok |

Shape **C** rules out the #168 bind cache as a cause: the old rebind-every-row shape loses too, and `SQL_RESET_PARAMS` does not clear the poison. Shape **E** is the exact call this PR now issues, and it is what justifies changing the C type and nothing else.

The new Firebird test on the parent commit — the tests are committed before the fix, so checking out the first commit reproduces this:

```
Mismatch on row 2, column 2
NULL <> 60.0

Expected result:            Actual result:
1  NULL NULL NULL NULL      1  NULL NULL NULL NULL
2  60.0 60.0 60   60        2  NULL NULL NULL 60
```

NUMERIC, DECIMAL and BIGINT lose the value that follows the NULL; the INTEGER control column keeps it. Green with the fix.

## Tests

`test/sql/firebird/firebird_copy.test` — NULL/value transitions on `NUMERIC(9,3)`, `DECIMAL(18,2)` and `BIGINT` with `INTEGER` as a control, from `INTEGER` and `DOUBLE` sources, NULL-first and value/NULL/value, through both the single-row and the batched paths; a `DECIMAL` source as a control that passed before; plus a block covering the non-numeric C types (integer to character, VARCHAR, DATE).

`test/sql/duckdb/duckdb_copy.test` — the same shape with one column per bound C type, so the typed-NULL path is exercised in every CI job. Passes before and after.

Ran locally on Windows:

- `--dbms Firebird` (whole suite) green, against a current Firebird ODBC 3.5 development build and Firebird 5.0.3.1.
- `--dbms DuckDB` (whole suite) green except `type_timestamp.test`, which fails identically on `main` — the current `duckdb-odbc` release returns `2020-12-31 23:58:59.123456` where the test expects second precision. Unrelated to this PR, but you may want to know it is red on the latest driver.
- `make test` — all 1406 assertions in 43 test cases pass.
- `make format-check` clean (clang-format 11.0.1, as in CI).

I could not exercise the MSSQL / MySQL / Postgres / DB2 / Oracle jobs locally, so those C-type mappings rest on CI. If some driver rejects a typed NULL, the smallest fallback is a `DbmsQuirks` flag defaulting to on, but I would rather see a failing job's diagnostics first than add one pre-emptively.

## Unrelated observation

While writing the driver-independent block I hit a pre-existing issue on the DuckDB ODBC driver that has nothing to do with NULLs: a whole-number DECIMAL parameter round-trips scaled down — `60.00::DECIMAL(18,2)` comes back as `0.60` — with no NULL anywhere in the source, and on `main`. `60.25` round-trips correctly, which is why the new block uses values with non-zero fractional digits (noted in a comment there). Happy to open a separate issue if that is useful.

---

⚠️ AI-assisted (Claude Code / Opus 5), reviewed by me; happy to iterate on any of it.
